### PR TITLE
fix: 회원가입 시 누락된 필수 필드 추가 및 API 명세 동기화

### DIFF
--- a/src/05-features/auth/ui/auth-modal.tsx
+++ b/src/05-features/auth/ui/auth-modal.tsx
@@ -54,7 +54,11 @@ const AuthModal: React.FC<AuthModalProps> = ({
         await authApi.signup({
           email: formData.email,
           password: formData.password,
+          passwordConfirm: formData.password,
           name: formData.name,
+          loginType: 'local',      // 백엔드 명세의 기본값
+          brainType: 'focused',    // 백엔드 명세의 기본값
+          membershipLevel: 'basic' // 백엔드 명세의 기본값
         });
         setIsLogin(true);
         setFormData({ ...formData, password: '' });

--- a/src/07-shared/api/auth.ts
+++ b/src/07-shared/api/auth.ts
@@ -8,6 +8,10 @@ export interface LoginRequest {
 
 export interface SignupRequest extends LoginRequest {
   name: string;
+  passwordConfirm: string; // 추가
+  loginType: string;      // 추가
+  brainType: string;      // 추가
+  membershipLevel: string; // 추가
 }
 
 export interface AuthResponse {


### PR DESCRIPTION
개요
회원가입 요청 시 백엔드 서버에서 요구하는 필수 필드들이 누락되어 발생하는 400 Bad Request 에러를 해결하고, 최신 API 명세에 맞춰 프론트엔드 데이터 구조를 업데이트했습니다.

변경 사항
인터페이스 확장: SignupRequest 인터페이스에 passwordConfirm, loginType, brainType, membershipLevel 필드를 추가했습니다.

요청 데이터 보완: AuthModal 컴포넌트의 회원가입 로직에서 백엔드 필수 파라미터를 포함하여 전송하도록 수정했습니다.

passwordConfirm: 입력한 비밀번호와 동일하게 설정

loginType: 'local' (기본값)

brainType: 'focused' (기본값)

membershipLevel: 'basic' (기본값)

결과
회원가입 요청 시 서버로부터 201 Created 응답 및 유저 객체 생성을 성공적으로 확인했습니다.