### PR TITLE
docs(architecture): stamp ADR-005 transition date + fix pre-push range

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -9,15 +9,24 @@ if [ "$CURRENT_BRANCH" = "main" ]; then
   exit 1
 fi
 
-# Gate 2: 마지막 10 커밋 메시지 commitlint 검증 (commitlint.config.js 기준)
-git log --format=%s -10 --no-merges | while IFS= read -r subject; do
-  if ! echo "$subject" | npx --no-install commitlint --config commitlint.config.js >/dev/null 2>&1; then
-    echo "BLOCKED: commit message violates commitlint rule:"
-    echo "  $subject"
-    echo "Fix: git reset --soft HEAD~N and rewrite commits. DO NOT force push."
-    exit 1
-  fi
-done || exit 1
+# Gate 2: push 대상 신규 커밋만 commitlint 검증 (origin/dev..HEAD 범위)
+# 과거 dev 히스토리는 체크에서 제외함 — origin/dev 없으면 fallback으로 최근 10개
+if git rev-parse --verify origin/dev >/dev/null 2>&1; then
+  SUBJECTS=$(git log --format=%s --no-merges origin/dev..HEAD)
+else
+  SUBJECTS=$(git log --format=%s --no-merges -10 HEAD)
+fi
+
+if [ -n "$SUBJECTS" ]; then
+  echo "$SUBJECTS" | while IFS= read -r subject; do
+    if ! echo "$subject" | npx --no-install commitlint --config commitlint.config.js >/dev/null 2>&1; then
+      echo "BLOCKED: commit message violates commitlint rule:"
+      echo "  $subject"
+      echo "Fix: git reset --soft HEAD~N and rewrite commits. DO NOT force push."
+      exit 1
+    fi
+  done || exit 1
+fi
 
 # Gate 3: uncommitted 변경 없음 확인 (untracked 파일 포함)
 if [ -n "$(git status --porcelain)" ]; then

--- a/docs/architecture/decisions/ADR-005-ci-advisory-transition.md
+++ b/docs/architecture/decisions/ADR-005-ci-advisory-transition.md
@@ -1,6 +1,6 @@
 # ADR-005: CI 게이트를 2주 advisory 기간 후 blocking으로 전환함
 
-- **Status**: Proposed
+- **Status**: Accepted
 - **Date**: 2026-04-18
 - **Applies to**: both repos (BE + FE)
 - **Deciders**: @gs07103
@@ -31,13 +31,10 @@ blocking 효과가 없음:
 1. `.github/workflows/commitlint.yml`의 `continue-on-error: true` → `false` 교체 PR
 2. GitHub repo Settings > Branch protection > Required status checks에 `commitlint` 추가
 
-> ⚠️ **Transition date 미박제 (작성 시점)**: Wave 2 머지가 완료되면 이 ADR을 편집하여
-> 실제 머지 날짜를 아래 `Transition date` 필드에 기입할 것.
-
 ## Transition date
 
-- **Wave 2 머지일**: TBD (Wave 2 머지 직후 이 ADR 편집하여 날짜 박제)
-- **Blocking 전환 기한**: Wave 2 머지일 + 14 days (D+14)
+- **Wave 2 머지일**: 2026-04-21 (BE PR #42 `fd57a31` create merge; FE PR #42 `daaf737` squash)
+- **Blocking 전환 기한**: 2026-05-05 (Wave 2 머지일 + 14 days)
 
 > FE 특이사항: FE는 6-step verify 파이프라인이 이미 적용됨 (PR #36).
 > commitlint는 Wave 5에서 새로 추가됨. advisory transition 규칙은 BE와 동일하게 적용됨.


### PR DESCRIPTION
## Summary
- ADR-005 Status `Proposed → Accepted`
- ADR-005 Transition date 박제: Wave 2 머지일 `2026-04-21` (BE PR #42 `fd57a31`; FE PR #42 `daaf737`) → Blocking 전환 기한 `2026-05-05`
- `.githooks/pre-push` 범위 버그 수정: HEAD last 10 → `origin/dev..HEAD` (과거 dev 히스토리 검증 제외, 팀 전체 push 차단 버그 해소)

## Why
- Wave 2 머지 이후 14일 블로킹 전환 기한이 ADR-005에 TBD로 남아 있었음 → 실제 날짜 박제
- pre-push hook이 과거 `fix(e2e):` scope 커밋을 commitlint `scope-case: kebab-case`로 block → 팀 전체 push 차단. 범위를 push 대상으로 좁혀 해결

## Test plan
- [x] 로컬에서 수정된 hook으로 `--no-verify` 없이 push 통과
- [ ] CI green (docs/chore 변경이라 큰 리스크 없음)

Co-authored-by: gs07103 <gwonseok02@gmail.com>