### PR TITLE
Phase 15 template intent retrofit (FE) + ADR-005 stamp + pre-push hook fix

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -e
+
+# Gate 1: main 브랜치 직접 push 차단
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [ "$CURRENT_BRANCH" = "main" ]; then
+  echo "BLOCKED: direct push to main is not allowed."
+  echo "Create a feature branch (feat/..., fix/..., etc.) and open a PR instead."
+  exit 1
+fi
+
+# Gate 2: 마지막 10 커밋 메시지 commitlint 검증 (commitlint.config.js 기준)
+git log --format=%s -10 --no-merges | while IFS= read -r subject; do
+  if ! echo "$subject" | npx --no-install commitlint --config commitlint.config.js >/dev/null 2>&1; then
+    echo "BLOCKED: commit message violates commitlint rule:"
+    echo "  $subject"
+    echo "Fix: git reset --soft HEAD~N and rewrite commits. DO NOT force push."
+    exit 1
+  fi
+done || exit 1
+
+# Gate 3: uncommitted 변경 없음 확인 (untracked 파일 포함)
+if [ -n "$(git status --porcelain)" ]; then
+  echo "BLOCKED: uncommitted changes exist. Commit or stash before pushing."
+  exit 1
+fi
+
+echo "Pre-push gate passed."
+echo "✅ pre-push checks passed"
+# TIP: 이 hook가 실행되지 않으면 git config core.hooksPath .githooks 1회 설정 필요함

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -9,15 +9,24 @@ if [ "$CURRENT_BRANCH" = "main" ]; then
   exit 1
 fi
 
-# Gate 2: 마지막 10 커밋 메시지 commitlint 검증 (commitlint.config.js 기준)
-git log --format=%s -10 --no-merges | while IFS= read -r subject; do
-  if ! echo "$subject" | npx --no-install commitlint --config commitlint.config.js >/dev/null 2>&1; then
-    echo "BLOCKED: commit message violates commitlint rule:"
-    echo "  $subject"
-    echo "Fix: git reset --soft HEAD~N and rewrite commits. DO NOT force push."
-    exit 1
-  fi
-done || exit 1
+# Gate 2: push 대상 신규 커밋만 commitlint 검증 (origin/dev..HEAD 범위)
+# 과거 dev 히스토리는 체크에서 제외함 — origin/dev 없으면 fallback으로 최근 10개
+if git rev-parse --verify origin/dev >/dev/null 2>&1; then
+  SUBJECTS=$(git log --format=%s --no-merges origin/dev..HEAD)
+else
+  SUBJECTS=$(git log --format=%s --no-merges -10 HEAD)
+fi
+
+if [ -n "$SUBJECTS" ]; then
+  echo "$SUBJECTS" | while IFS= read -r subject; do
+    if ! echo "$subject" | npx --no-install commitlint --config commitlint.config.js >/dev/null 2>&1; then
+      echo "BLOCKED: commit message violates commitlint rule:"
+      echo "  $subject"
+      echo "Fix: git reset --soft HEAD~N and rewrite commits. DO NOT force push."
+      exit 1
+    fi
+  done || exit 1
+fi
 
 # Gate 3: uncommitted 변경 없음 확인 (untracked 파일 포함)
 if [ -n "$(git status --porcelain)" ]; then

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,20 @@
+name: commitlint
+on:
+  pull_request:
+    branches: [main, dev]
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm ci
+      - uses: wagoid/commitlint-github-action@v6
+        with:
+          commitDepth: 1
+          failOnErrors: true
+        continue-on-error: true   # advisory 2주 — ADR-005

--- a/CODERABBIT-PROMPT-GUIDE.md
+++ b/CODERABBIT-PROMPT-GUIDE.md
@@ -1,0 +1,254 @@
+# CodeRabbit Prompt Guide — Mind Signal Frontend
+
+`.coderabbit.yaml`의 `path_instructions`를 작성·확장할 때 참조하는 가이드.
+이 문서는 `.coderabbit.yaml` 설정 파일의 companion 문서임 — 파일 자체를 대체하지 않음.
+
+---
+
+## 1. CodeRabbit이란
+
+CodeRabbit은 GitHub PR에 자동으로 코드 리뷰를 달아주는 AI 리뷰어임.
+PR이 열리면 요약(high-level summary), 파일별 인라인 코멘트, 이슈 심각도 태그를 자동 생성함.
+레포별 규칙은 `.coderabbit.yaml`로 정의하고, `path_instructions`에 경로 패턴별 리뷰 프롬프트를 작성함.
+
+CodeRabbit은 **로직·아키텍처·보안 리뷰** 도구임. 포맷팅(Prettier/ESLint가 담당)과 커밋 메시지 컨벤션(commitlint가 담당)은 CodeRabbit의 역할이 아님.
+
+---
+
+## 2. MS(Mind Signal) FE 레포에서의 사용 원칙
+
+### 2-1. 한국어 명사형 종결 주석 감시
+
+이 레포의 코딩 컨벤션에 따라 모든 코드 주석은 명사형으로 종결함.
+
+- 올바른 형식: `// 소켓 연결 초기화함`, `// API 응답 파싱함`, `// 인증 토큰 주입 완료`
+- 잘못된 형식: `// 소켓 연결을 초기화합니다`, `// API 응답을 파싱하는 함수`, `// ~하는 로직`
+
+CodeRabbit이 이 규칙 위반을 발견하면 NIT 코멘트를 달도록 `path_instructions`에 명시함.
+
+### 2-2. FSD 번호 레이어 경계 위반 감지
+
+FE FSD 레이어 구조 (번호가 클수록 더 foundational):
+
+```text
+01-app/       ← Next.js routes, Providers, root layout
+03-pages/     ← page-level components (app/에서 import)
+04-widgets/   ← Navbar, Footer, SignalChart
+05-features/  ← auth, sessions, signals, chat-assistant
+07-shared/    ← api, config, types, constants, utils
+```
+
+의존성 방향: 번호가 작은 레이어 → 번호가 큰 레이어 import만 허용.
+역방향 import(예: `07-shared`에서 `05-features` import)는 MUST_FIX 위반.
+
+`dependency-cruiser`가 1차 방어(CI 게이트), CodeRabbit은 리뷰 레벨 2차 방어임.
+CodeRabbit은 `dependency-cruiser`가 잡지 못하는 **의도적 경계 우회 패턴** (예: 동적 import, 우회 재export)을 리뷰 코멘트로 지적함.
+
+### 2-3. React 19 + React Compiler 관례 — manual 최적화 지양
+
+React Compiler (Forget)가 활성화되어 있음. 다음 패턴은 불필요하거나 위험함:
+
+- `useMemo`, `useCallback` 수동 추가 — Compiler가 자동 처리하므로 SHOULD_FIX
+- `React.memo()` 불필요한 래핑 — Compiler가 자동 처리하므로 SHOULD_FIX
+- 이미 Compiler가 처리 중인 컴포넌트에 중복 최적화 추가 시 SHOULD_FIX 코멘트
+
+### 2-4. `'use client'` 디렉티브 명시 위치 검증
+
+- `useState`, `useEffect`, `useRef`, 브라우저 API(`localStorage`, `window` 등), 이벤트 핸들러를 사용하는 모든 컴포넌트 최상단에 `'use client'` 선언 필수
+- 누락 시 MUST_FIX (SSR 환경에서 hydration 에러 발생)
+- `'use client'` 없이 Client-only API를 사용하는 컴포넌트 = MUST_FIX
+
+### 2-5. Zod form 검증 + `07-shared/config/config.ts` env parse
+
+- 환경변수는 반드시 `src/07-shared/config/config.ts`의 `config` 객체 경유
+- `process.env.NEXT_PUBLIC_*` 직접 접근 = MUST_FIX
+- form onSubmit 핸들러에서 Zod 검증 없이 서버로 전송 = SHOULD_FIX
+
+### 2-6. Axios instance 경유 강제 (직접 fetch/axios 금지)
+
+- 모든 API 호출은 `src/07-shared/api/base.ts`의 Axios 인스턴스 사용 필수
+- `fetch()` 직접 사용 = MUST_FIX (JWT 인터셉터 우회)
+- `axios.create()` 별도 인스턴스 생성 = MUST_FIX
+- 자세한 패턴: `.claude/rules/api-patterns.md` 참조
+
+---
+
+## 3. 프롬프트 패턴 레시피 — FE 특화 4개
+
+`.coderabbit.yaml`의 `path_instructions`에 붙여 넣어 재사용 가능한 프롬프트 예시.
+
+### 레시피 1: TSX 컴포넌트 — FSD 경계 체크
+
+```yaml
+- path: "src/**/*.tsx"
+  instructions: |
+    FSD layer boundary check (번호가 작은 레이어는 번호가 큰 레이어만 import 가능):
+    - 07-shared MUST NOT import from 05-features, 04-widgets, 03-pages.
+    - 05-features MUST NOT import from 04-widgets or 03-pages.
+    - Flag any upward cross-layer import as MUST_FIX.
+
+    React Compiler (Forget) is active — do NOT add manual memoization:
+    - Manual `useMemo`, `useCallback`, or `React.memo()` without a documented reason = SHOULD_FIX.
+    - Flag with: "React Compiler handles this automatically. Remove unless you have a measured perf reason."
+
+    Security:
+    - Hardcoded secrets or API keys = MUST_FIX.
+    - `dangerouslySetInnerHTML` without explicit sanitization = MUST_FIX.
+    - Unvalidated redirects = MUST_FIX.
+
+    Korean comment style:
+    - All inline comments must end in a noun form (명사형 종결): ~함, ~임, ~반환, ~처리, ~사용.
+    - Sentence-ending forms (~합니다, ~하는 함수) are a NIT violation.
+
+    Do NOT comment on formatting — Prettier and ESLint own that.
+```
+
+### 레시피 2: Hook 파일 — Server/Client boundary + `'use client'` 검증
+
+```yaml
+- path: "src/**/*.ts"
+  instructions: |
+    Server/Client boundary:
+    - Any hook or utility using `useState`, `useEffect`, `useRef`, `localStorage`,
+      `window`, `document`, or event handlers must be in a file with `'use client'`
+      at the top, OR called only from a component with `'use client'`.
+    - Flag missing `'use client'` in a file that uses browser APIs as MUST_FIX.
+
+    API call pattern:
+    - All HTTP calls must go through the Axios instance in `src/07-shared/api/base.ts`.
+    - Direct `fetch()` or standalone `axios.create()` = MUST_FIX.
+    - `process.env.NEXT_PUBLIC_*` direct access = MUST_FIX — use `config` from config.ts.
+
+    FSD boundary:
+    - 07-shared utilities MUST NOT import from 05-features or above.
+    - Flag cross-layer upward imports as MUST_FIX.
+
+    Do NOT comment on formatting.
+```
+
+### 레시피 3: Route/API 핸들러 — Zod validation + `NextResponse.json` 사용 확인
+
+```yaml
+- path: "src/app/**/route.ts"
+  instructions: |
+    Next.js App Router API route rules:
+    - All POST/PUT/PATCH handlers must validate the request body with Zod before processing.
+      Missing validation = MUST_FIX.
+    - Responses must use `NextResponse.json(...)` — never `res.json()` (Pages Router style).
+      Wrong response method = MUST_FIX.
+    - Auth-protected routes must verify the JWT token early in the handler.
+      Flag missing auth check on routes that access user-specific data as MUST_FIX.
+    - Errors must not be silently swallowed (empty catch block) = MUST_FIX.
+    - Environment access via `config` object only — direct `process.env.*` = MUST_FIX.
+
+    Do NOT comment on formatting or import ordering.
+```
+
+### 레시피 4: 한국어 명사형 주석 스타일 NIT 패턴
+
+```yaml
+- path: "src/**"
+  instructions: |
+    Korean comment convention (명사형 종결):
+    - All Korean comments in code blocks must end with a noun-form terminator:
+      ~함, ~임, ~반환, ~생성, ~처리, ~사용, ~완료, ~연결, ~구독, ~발생, ~주입.
+    - Prohibited endings: ~합니다, ~입니다, ~하는 함수, ~하는 역할, ~하는 로직.
+    - Flag violations as NIT with a corrected version in the comment.
+    - English comments are exempt from this rule.
+```
+
+---
+
+## 4. `.coderabbit.yaml` 편집 가이드
+
+### 현재 FE `.coderabbit.yaml` 설정 요약
+
+현재 `mind-signal-frontend/.coderabbit.yaml`의 핵심 설정:
+
+- `language: ko-KR` — 리뷰 코멘트 언어 한국어
+- `reviews.profile: chill` — 보수적인 리뷰 강도 (과도한 nitpick 최소화)
+- `reviews.auto_review.enabled: true` — PR 자동 리뷰 활성화 (drafts 제외)
+- `reviews.auto_review.base_branches: [main, dev]` — main, dev 대상 PR만 자동 리뷰
+- `chat.auto_reply: true` — `@coderabbitai` 멘션 시 자동 답변
+- `reviews.path_instructions` — 경로별 **6개** 규칙 등록됨:
+  - `src/07-shared/**`: 최하위 레이어 import 위반 + `process.env` 직접 접근 금지
+  - `src/05-features/**`: FSD 상위 레이어 import 금지 + Axios 인스턴스 사용 강제
+  - `src/03-pages/**`: 다른 page 직접 import 금지
+  - `src/**/*.tsx`: `any` 타입 금지 + `'use client'` 위치 확인 + 보안 점검
+  - `src/**/*.test.{ts,tsx}`: happy path + error path 커버리지
+  - `e2e/**/*.spec.ts`: flaky selector 방지 + 테스트 간 상태 격리
+
+> **주의**: `ignore_formatting` 키가 현재 `.coderabbit.yaml`에 없음.
+> 포맷팅 코멘트를 억제하려면 각 `path_instructions` 항목에 `"Do NOT comment on formatting."` 한 줄 추가 권장.
+
+### 새 규칙 추가 시 주의점
+
+1. **YAML 들여쓰기**: `path_instructions` 항목은 2-space 들여쓰기. `instructions` 블록은 `|` (리터럴 블록 스칼라) 사용.
+
+   ```yaml
+   path_instructions:
+     - path: "src/**/*.tsx"
+       instructions: |
+         첫 번째 줄.
+         두 번째 줄.
+   ```
+
+2. **glob 패턴**: `"src/**/*.tsx"` (큰따옴표 필수). `**`는 재귀 디렉토리 매칭.
+   - `src/**/route.ts` — App Router API route 파일
+   - `src/07-shared/**` — shared 레이어 전체
+   - `e2e/**/*.spec.ts` — Playwright E2E 테스트
+
+3. **tone_instructions 우선순위**: `profile: chill`은 전체 리뷰 강도를 낮춤.
+   path_instructions 안에서 `MUST_FIX`로 명시하면 chill 설정보다 강제력이 높음.
+   중요한 규칙은 반드시 `MUST_FIX`로 태그할 것.
+
+4. **`chat.auto_reply: true`** — CodeRabbit이 PR 코멘트에 자동 답변함.
+   CodeRabbit에게 직접 질문하려면 PR 코멘트에 `@coderabbitai` 멘션.
+
+---
+
+## 5. 리뷰 사이클
+
+```text
+PR 생성
+  ↓
+CodeRabbit 자동 분석 (수 분 소요)
+  ↓
+high-level summary + 파일별 인라인 코멘트 생성
+  ↓
+개발자: 코멘트 확인 + 수정
+  ↓
+`@coderabbitai review` 코멘트 → 재리뷰 트리거
+  ↓
+머지
+```
+
+### 심각도 3단계
+
+| 태그 | 의미 | 대응 |
+|---|---|---|
+| `MUST_FIX` | 아키텍처·보안·기능 버그 — 머지 전 반드시 수정 | 즉시 수정 후 재리뷰 |
+| `SHOULD_FIX` | 품질·유지보수성 이슈 — 강력 권장 | 현 PR 또는 후속 PR |
+| `NIT` | 스타일·네이밍 소수의견 — 선택적 | 무시하거나 기회 시 반영 |
+
+> **Phase 14 PR #40 (SEQUENTIAL UX) 사례**: FE PR에서 CodeRabbit은 BE PR #41 대비 nitpick 수가 적었음.
+> React Compiler 활성화와 Prettier/ESLint 사전 통과 덕분에 포맷·최적화 관련 코멘트가 줄어든 것으로 분석됨.
+> MUST_FIX는 후속 PR로 미루지 않는 것을 원칙으로 함.
+
+---
+
+## 6. 기존 `.coderabbit.yaml` 설정 요약
+
+파일 위치: `mind-signal-frontend/.coderabbit.yaml`
+
+| 항목 | 현재 값 | 비고 |
+|---|---|---|
+| 리뷰 언어 | `ko-KR` | 한국어 코멘트 |
+| 리뷰 강도 | `chill` | 과도한 nitpick 방지 |
+| 포맷팅 무시 | 설정 없음 (각 path_instructions에 개별 명시 필요) | BE는 `ignore_formatting: true` 있음 |
+| 자동 리뷰 | `true` (draft 제외) | main, dev 브랜치 대상 |
+| 채팅 자동 답변 | `true` | `@coderabbitai` 멘션 시 |
+| path_instructions 수 | 6개 | 07-shared / 05-features / 03-pages / tsx / test / e2e |
+
+현재 `path_instructions`의 `src/05-features/**` 항목에 FSD 번호 레이어 방향 규칙이 명시되어 있음.
+React Compiler 관련 `useMemo`/`useCallback` 지양 규칙 및 `'use client'` 위치 검증은 `src/**/*.tsx` 항목에 추가 권장.

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,24 @@
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'type-enum': [
+      2,
+      'always',
+      [
+        'feat',
+        'fix',
+        'docs',
+        'chore',
+        'refactor',
+        'test',
+        'ci',
+        'revert',
+        'perf',
+        'style',
+      ],
+    ],
+    'scope-case': [2, 'always', 'kebab-case'],
+    // start-case·pascal-case·upper-case 3종 금지 → 순수 영어 소문자 강제, 한국어/파일명 혼용 subject는 sentence-case 허용
+    'subject-case': [2, 'never', ['start-case', 'pascal-case', 'upper-case']],
+  },
+};

--- a/docs/architecture/decisions/ADR-001-numbered-fsd-layers.md
+++ b/docs/architecture/decisions/ADR-001-numbered-fsd-layers.md
@@ -1,0 +1,79 @@
+# ADR-001: FSD 레이어 명명에 번호 prefix를 유지함
+
+- **Status**: Accepted
+- **Date**: 2026-04-18
+- **Applies to**: both repos (BE + FE)
+- **Deciders**: @gs07103
+- **Related**: ADR-003 (dependency-cruiser 도입)
+
+## Context
+
+Mind Signal 프로젝트는 Feature-Sliced Design(FSD)을 채택하고 있으나,
+레이어 명명 방식이 템플릿 표준(`shared/entities/features/...`)과 다름.
+MS는 `07-shared → 06-entities → 05-features → 02-processes → 01-app`과 같이
+**import 방향과 역방향인 번호 prefix**를 사용함.
+
+이 번호 체계는 2026-04-18 현재 BE와 FE 두 레포 모두에서 운영 중이며,
+TypeScript path alias(`@07-shared/`, `@06-entities/` 등),
+라우터, 테스트 파일 전반에 걸쳐 정착됨.
+Phase 15에서 llm-setup-templates v1.0.0의 tooling을 retrofit하는 시점에
+레이어 이름 변경 여부를 명시적으로 결정해야 함.
+
+## Decision
+
+번호 prefix 레이어 명명(`07-shared → 06-entities → 05-features → 02-processes → 01-app`)을
+두 레포에서 그대로 유지함. 템플릿 표준 명칭으로의 리네임은 수행하지 않음.
+
+## Alternatives considered
+
+### Option A: 템플릿 표준으로 리네임 (`shared/entities/features/...`)
+
+FSD 커뮤니티 표준과 정렬됨. 서드파티 FSD 도구(eslint-plugin-fsd-lint 등)와의
+호환성이 높아짐.
+
+**Trade-offs**: 번호 체계가 사라지므로 import 방향 시각적 식별이 어려워짐.
+Path alias, 라우터, 테스트, 설정 파일 수십 곳을 일괄 수정해야 함.
+운영 중 레포에서 대규모 리네임은 병합 충돌 및 버그 리스크가 높음.
+
+**Rejected because**: 리네임 비용(엔지니어링 시간 + 회귀 리스크)이 정합성 이점을
+초과함. `dependency-cruiser`가 번호 레이어 커스텀 설정을 완전히 지원함(ADR-003).
+
+### Option B (status quo): 번호 prefix 유지
+
+현재 방식을 그대로 유지함.
+
+**Trade-offs**: FSD 커뮤니티 표준과 다소 다름. 신규 기여자가 번호 체계를 이해해야 함.
+
+**Selected**: 운영 중 레포의 안정성 우선, tooling 차원에서 완전히 지원 가능함.
+
+## Consequences
+
+**더 쉬워지는 것:**
+
+- import 문에서 레이어 번호로 의존 방향을 즉시 식별할 수 있음
+  (`@07-shared/` → `@06-entities/` → `@05-features/` 순서가 명확함)
+- 기존 코드베이스 유지 — 회귀 리스크 없음
+- `dependency-cruiser` 커스텀 규칙으로 번호 레이어 경계 강제 가능함 (ADR-003)
+
+**더 어려워지는 것:**
+
+- 외부 FSD 도구(eslint-plugin-fsd-lint)의 기본 설정은 번호 레이어를 인식하지 못함.
+  `dependency-cruiser`만 사용하는 이유(ADR-003)
+
+**기술 부채:**
+
+- 신규 팀원 온보딩 시 번호 체계 별도 설명 필요함.
+  `docs/architecture/overview.md`의 레이어 설명으로 완화함
+
+## Implementation notes
+
+- Path alias 유지: `@07-shared/`, `@06-entities/`, `@05-features/`, `@02-processes/`, `@01-app/`
+- dependency-cruiser 규칙 파일 `.dependency-cruiser.cjs`에서 번호 레이어 패턴으로
+  경계 강제함 (ADR-003, Wave 2에서 구현)
+- `CLAUDE.md §4 FSD 아키텍처 레이어 규칙` — 번호 레이어 설명 유지됨
+
+## References
+
+- [Feature-Sliced Design 공식 문서](https://feature-sliced.design/)
+- ADR-003 (dependency-cruiser 선택)
+- FE `feat/ci-architecture-enforcement` 브랜치 — 132모듈 0 violations 실증 (2026-04-16)

--- a/docs/architecture/decisions/ADR-002-fe-vitest.md
+++ b/docs/architecture/decisions/ADR-002-fe-vitest.md
@@ -1,0 +1,86 @@
+# ADR-002: FE 테스트 러너로 Vitest를 유지함
+
+<!-- ⚠️ 이 ADR은 FE(mind-signal-frontend) 의사결정임.
+     BE는 정보성 참조 사본 `ADR-002-fe-vitest-reference.md`으로 별도 보관.
+     BE 에이전트는 이 ADR을 읽고 Vitest 관련 도구를 도입하는 일이 없도록 주의할 것.
+     BE는 여전히 Jest + supertest를 사용함. -->
+
+- **Status**: Accepted
+- **Date**: 2026-04-18
+- **Applies to**: FE only (primary decision — BE는 `ADR-002-fe-vitest-reference.md` 참조)
+- **Deciders**: @gs07103
+- **Related**: ADR-001 (번호 FSD 레이어), ADR-003 (dependency-cruiser)
+
+## Context
+
+mind-signal-frontend는 Vitest(`@vitest/browser`)를 사용하여 141개 테스트를
+실브라우저 환경에서 실행 중임. Phase 15 retrofit 과정에서 FE 테스트 러너를
+Jest로 교체할지 여부를 결정해야 함.
+
+- 기존 테스트: 141개 (`npm run test` 기준, PR #36 머지 이후)
+- 현재 환경: `@vitest/browser` + `@testing-library/jest-dom/vitest`
+- FE `feat/ci-architecture-enforcement` 브랜치에서 64개 추가 테스트 모두 Vitest로 작성됨
+
+## Decision
+
+FE는 Vitest를 유지함. Jest로의 교체는 수행하지 않음.
+
+## Alternatives considered
+
+### Option A: Jest + jsdom으로 교체
+
+템플릿 표준(typescript-template)과 동일한 테스트 러너로 통일됨.
+
+**Trade-offs**: `@vitest/browser`의 실브라우저 환경이 jsdom으로 대체되면
+브라우저 DOM API 동작 충실도가 낮아짐. 141개 테스트 전체 재작성 필요.
+`vi.mock` → `jest.mock`, `vitest -u` → `npm test -- -u`, import 전략 전면 수정 필요.
+
+**Rejected because**: 141개 테스트 재작성 비용이 Vitest→Jest 통일의 이점을 초과함.
+실브라우저 테스트 환경(`@vitest/browser`)은 FE 특성상 유지 가치가 높음.
+
+### Option B (status quo): Vitest 유지
+
+**Selected**: 재작성 비용 없음, 실브라우저 환경 유지, CI 파이프라인과 안정적으로 연동됨.
+
+## Consequences
+
+**더 쉬워지는 것:**
+
+- 기존 141개 테스트 전량 유지됨
+- `@vitest/browser` 실브라우저 환경으로 DOM 동작 충실도 높은 테스트 유지됨
+
+**더 어려워지는 것:**
+
+- BE(Jest)와 FE(Vitest)의 테스트 러너가 다름. 코드 공유 시 mock 패턴이 다름.
+  → BE 에이전트는 `jest.mock`, FE 에이전트는 `vi.mock` 사용
+
+**기술 부채:**
+
+- BE/FE test-modification.md가 각각 다른 러너 기준으로 작성되어야 함.
+  BE는 Jest variant, FE는 Vitest variant로 분리됨
+
+## BE implications (BE 에이전트 참조용)
+
+BE는 여전히 **Jest + supertest**를 사용함. 이 ADR이 BE에 미치는 영향:
+
+- `jest.mock`, `jest.fn()`, `npm test -- -u` 패턴 유지
+- `@testing-library/jest-dom` (Vitest 버전 아님)
+- BE `.claude/rules/test-modification.md`는 Jest 기준으로 작성됨
+- BE는 이 ADR의 정보성 참조 사본(`ADR-002-fe-vitest-reference.md`)만 보관
+
+## Vitest ↔ Jest 핵심 대응표 (FE 작업 시 참조)
+
+| Jest | Vitest (FE) |
+|---|---|
+| `jest.mock(...)` | `vi.mock(...)` |
+| `jest.fn()` | `vi.fn()` |
+| `jest.spyOn(...)` | `vi.spyOn(...)` |
+| `npm test -- -u` | `vitest -u` |
+| `jest-environment-jsdom` | `@vitest/browser` |
+| `@testing-library/jest-dom` | `@testing-library/jest-dom/vitest` |
+
+## References
+
+- FE `feat/ci-architecture-enforcement` 브랜치 (2026-04-16) — 64 tests Vitest 기준
+- [Vitest 공식 문서](https://vitest.dev/)
+- [Vitest Browser Mode](https://vitest.dev/guide/browser.html)

--- a/docs/architecture/decisions/ADR-003-dependency-cruiser-over-fsd-lint.md
+++ b/docs/architecture/decisions/ADR-003-dependency-cruiser-over-fsd-lint.md
@@ -1,0 +1,97 @@
+# ADR-003: FSD 경계 검사 도구로 dependency-cruiser만 사용함
+
+- **Status**: Accepted
+- **Date**: 2026-04-18
+- **Applies to**: both repos (BE + FE)
+- **Deciders**: @gs07103
+- **Related**: ADR-001 (번호 FSD 레이어)
+
+## Context
+
+FSD 레이어 경계를 자동으로 검사하는 도구로 두 가지 선택지가 있음:
+
+1. **eslint-plugin-fsd-lint**: ESLint 플러그인. `forbidden-imports`, `no-relative-imports`,
+   `no-public-api-sidestep` 규칙 제공. 그러나 `shared/features/...` 형태의 표준 레이어
+   이름을 하드코딩 의존함
+2. **dependency-cruiser**: 정규식 기반 커스텀 규칙. 번호 레이어(`07-shared` 등)를
+   포함한 임의의 경계 패턴 정의 가능
+
+Phase 15에서 CI에 FSD 경계 검사 게이트를 추가하기로 결정됨.
+ADR-001에서 번호 prefix 레이어를 유지하기로 결정했으므로,
+두 도구 중 번호 레이어를 지원하는 도구를 선택해야 함.
+
+FE `feat/ci-architecture-enforcement` 브랜치(2026-04-16)에서 dependency-cruiser를
+번호 레이어 4규칙으로 설정하여 **132모듈 252의존성, 0 violations** 실증 완료.
+
+## Decision
+
+`dependency-cruiser@^17.3.10`만 사용함. `eslint-plugin-fsd-lint`는 도입하지 않음.
+
+## Alternatives considered
+
+### Option A: eslint-plugin-fsd-lint 단독 사용
+
+ESLint 파이프라인에 통합되므로 `npm run lint`만으로 FSD 경계 검사 가능함.
+
+**Trade-offs**: 번호 레이어(`07-shared`, `05-features` 등)를 인식하지 못함.
+플러그인 내부에 `shared/features/...` 하드코딩 의존성 존재함.
+ADR-001과 충돌 — 표준 레이어 이름으로 리네임하지 않는 한 사용 불가.
+
+**Rejected because**: ADR-001과 정면 충돌. 번호 레이어 커스텀 지원 불확실.
+
+### Option B: eslint-plugin-fsd-lint + dependency-cruiser 병용
+
+두 도구를 병용하여 커버리지를 높임.
+
+**Trade-offs**: eslint-plugin-fsd-lint가 번호 레이어를 인식하지 못하면
+모든 import에서 false positive가 발생함. 도구 충돌 디버깅 비용 증가.
+
+**Rejected because**: false positive 리스크가 병용의 이점을 초과함.
+단일 도구가 같은 문제를 해결 가능하면 병용 불필요.
+
+### Option C (selected): dependency-cruiser 단독
+
+**Trade-offs**: ESLint와 별도 파이프라인 step(`npm run depcruise`)이 필요함.
+설정 파일(`.dependency-cruiser.cjs`)이 추가됨.
+
+**Selected**: 번호 레이어 완전 지원, FE 브랜치에서 0 violations 실증, 단일 도구로 단순함.
+
+## Consequences
+
+**더 쉬워지는 것:**
+
+- 번호 레이어(`07-shared → 01-app`)를 있는 그대로 검사함
+- 정규식 기반 커스텀 규칙으로 FE 특화 경계 정의 가능함
+  (예: `no-db-in-features`, `no-upward-from-shared`)
+- CI 6단계 파이프라인의 `Architecture` step에 통합됨
+
+**더 어려워지는 것:**
+
+- `npm run lint`와 별도로 `npm run depcruise`를 실행해야 함.
+  `npm run verify`로 통합하여 단일 명령으로 해결함
+
+**기술 부채:**
+
+- `.dependency-cruiser.cjs` 설정 파일이 레이어 구조 변경 시 함께 수정되어야 함.
+  레이어 추가·삭제 시 이 파일을 업데이트하는 절차를 팀에 공유해야 함
+
+## Implementation notes
+
+FE `.dependency-cruiser.cjs` 핵심 규칙 4종 (PR #36에서 구현):
+
+```js
+// (a) no-db-in-features: 05-features → DB 드라이버(prisma, drizzle-orm 등) 직접 import 금지
+// (b) no-db-in-pages: 03-pages → DB 드라이버 직접 import 금지
+// (c) no-upward-from-shared: 07-shared → 상위 레이어(05-features, 04-widgets, 03-pages) import 금지
+// (d) no-upward-from-widgets: 04-widgets → 03-pages import 금지
+```
+
+- 버전: `dependency-cruiser@^17.3.10` (FE 브랜치와 동일)
+- CI step: `npm run depcruise` (`continue-on-error: true` advisory 2주, ADR-005)
+
+## References
+
+- FE `feat/ci-architecture-enforcement` 브랜치 (2026-04-16) — 0 violations 실증
+- [dependency-cruiser 공식 문서](https://github.com/sverweij/dependency-cruiser)
+- ADR-001 (번호 FSD 레이어 유지 결정)
+- ADR-005 (CI advisory → blocking 전환 정책)

--- a/docs/architecture/decisions/ADR-004-engine-url-abstraction-reference.md
+++ b/docs/architecture/decisions/ADR-004-engine-url-abstraction-reference.md
@@ -1,0 +1,130 @@
+# ADR-004: Python 엔진 접근을 URL 추상화 + engineRegistryService로 캡슐화함
+
+<!-- ⚠️ 이 ADR은 BE(mind-signal-backend) 의사결정임. FE 작업에는 직접 영향 없음.
+     2PC 확장 시 엔진 URL을 env로 다루는 BE 측 계약 인지 목적의 정보성 참조 사본.
+     BE primary 파일: `mind-signal-backend/docs/architecture/decisions/ADR-004-engine-url-abstraction.md`
+     FE 에이전트가 이 파일을 읽고 `engineRegistryService` 등 BE 전용 서비스를 수정하는 일이 없도록 주의할 것. -->
+
+- **Status**: Accepted
+- **Date**: 2026-04-18
+- **Applies to**: BE (2PC 확장 경계 핵심) — FE 작업에 직접 영향 없음
+- **Deciders**: @gs07103
+- **Related**: ADR-001 (번호 FSD 레이어)
+
+## Context
+
+Mind Signal 백엔드는 EEG 측정 시 Python 엔진(`core.main`)을 실행해야 함.
+현재는 `measurement.service.ts`가 세션 시작 시 `child_process.spawn`으로
+Python 프로세스를 온디맨드로 직접 실행하는 방식을 사용함.
+
+이 방식은 1PC 환경에서 동작하지만, 2PC 확장(Subject PC ↔ Operator PC 분리,
+또는 원격 PC에서 헤드셋 운용) 시 다음 문제가 발생함:
+
+- `child_process.spawn`은 로컬 프로세스만 실행 가능함
+- 원격 PC의 Python 프로세스를 BE가 직접 spawn할 수 없음
+- 엔진 URL이 코드에 하드코딩되면 환경 전환 시 코드 수정 필요
+
+현재 코드는 `config.ts:57`에서 `DATA_ENGINE_URL = process.env.DATA_ENGINE_URL || 'http://localhost:5002'`로
+환경변수 fallback을 이미 지원함. Python 엔진은 시작 후 `/engine/register`로
+pyngrok URL을 BE에 등록하는 패턴이 구현되어 있음.
+
+Phase 15 retrofit에서 이 패턴을 문서화하고 드리프트 방지 규칙으로 강제해야 함.
+
+## Decision
+
+엔진 접근은 반드시 `DATA_ENGINE_URL` env(fallback) + `engineRegistryService` 경유
+HTTP/WS를 통해서만 이루어짐. Python 엔진은 on-demand spawn 후 `/engine/register`로
+pyngrok URL(또는 localhost fallback)을 BE에 자동 등록함. `measurementService`
+추상화 하위에 캡슐화되며, 서비스 코드에서 `child_process.spawn` 직접 호출은 금지됨.
+
+## Alternatives considered
+
+### Option A: child_process.spawn 직결 (현상 유지)
+
+Python 경로(`DATA_ENGINE_PYTHON`)를 env로 받아서 `child_process.spawn`으로 직접 실행함.
+
+**Trade-offs**: 단순하고 직관적임. 그러나 엔진이 항상 BE와 같은 PC에 있어야 함.
+2PC 환경에서는 원격 PC의 Python 실행 불가. 코드가 로컬 실행 환경에 강하게 결합됨.
+
+**Rejected because**: 2PC 확장 시 코드 대규모 수정 필요. URL 추상화로 동일한 1PC 동작을
+유지하면서 2PC를 미래 호환으로 열어둘 수 있음.
+
+### Option B: gRPC / WebSocket 전용 프로토콜
+
+엔진과 BE 사이를 전용 RPC 프로토콜로 연결함.
+
+**Trade-offs**: 타입 안전성과 성능이 향상됨. 그러나 Python + Node.js 양쪽에
+gRPC 스택 추가 필요. 현재 팀 규모(1인)에서 오버엔지니어링.
+
+**Rejected because**: 현재 HTTP/WS 조합으로 충분함. 프로토콜 전환은 독립 Phase.
+
+### Option C (selected): DATA_ENGINE_URL + engineRegistryService
+
+현재 구현의 패턴을 명문화하고 드리프트 방지 규칙으로 강제함.
+
+**Selected**: 코드 변경 없이 1PC 동작 유지, 2PC 확장 시 원격 PC에서 `/engine/register`만
+호출하면 됨. 이미 검증된 패턴이므로 리스크 없음.
+
+## Consequences
+
+**더 쉬워지는 것:**
+
+- 2PC 확장 시: 원격 PC의 Python 엔진이 BE의 `/engine/register`를 HTTP POST로
+  호출하면 BE는 해당 URL을 메모리에 등록하고 이후 요청을 해당 URL로 전송함.
+  코드 변경 없이 원격 엔진 수용 가능함
+- 엔진 URL이 pyngrok 등으로 동적으로 변경되어도 register 재호출로 갱신됨
+
+**더 어려워지는 것:**
+
+- `child_process.spawn` 직결보다 등록 단계가 하나 추가됨.
+  로컬 개발 시 Python 기동 후 `/engine/register` 호출이 자동으로 일어나야 함
+  (Python 코드에서 시작 시 자동 등록)
+
+**기술 부채:**
+
+- `engineRegistryService`의 등록된 URL이 메모리에만 저장됨. BE 재시작 시
+  Python 엔진이 재등록하지 않으면 URL 소실. 재등록 재시도 로직이 필요함 (Phase 16+)
+
+## 2PC 확장 경계 제약 (HARD CONSTRAINTS, BE 관할)
+
+아래 제약은 BE `.claude/rules/architecture.md`에 박제됨.
+FE는 BE Socket.io 스트림만 수신하므로 이 제약의 직접 적용 대상이 아님.
+2PC 확장 시 FE 코드 변경은 불필요함.
+
+| 제약 | 내용 |
+|---|---|
+| **Engine-location abstraction** | 서비스 코드에서 `child_process.spawn` 직접 호출 금지. 반드시 `engineRegistryService` 경유 (BE 관할) |
+| **Channel keying** | Redis 채널 키는 `mind-signal:{groupId}:subject:{subjectIndex}` 형식만 허용. PC/host 정보 포함 금지 |
+| **Timestamp source of truth** | 서버측 ingest timestamp가 단일 진실. client-local clock은 intra-batch ordering에만 사용. 2PC NTP/LSL 처리는 Phase 16+에서 별도 ADR |
+
+## Implementation notes (BE 전용)
+
+- `engineRegistryService`: `src/02-processes/engine/services/engine-registry.service.ts`
+- `engineProxyService`: `src/02-processes/engine/services/engine-proxy.service.ts`
+- `config.dataEngine.baseUrl`: `config.ts:57` — `DATA_ENGINE_URL` env, fallback `http://localhost:5002`
+- Python 등록 엔드포인트: `POST /engine/register` — pyngrok URL 또는 localhost URL 수신
+
+### 환경별 URL 패턴
+
+| 환경 | `DATA_ENGINE_URL` | 실제 등록 URL |
+|---|---|---|
+| 로컬 개발 | `http://localhost:5002` (fallback) | Python spawn 후 자동 등록 |
+| Staging (ngrok) | `http://localhost:5002` (fallback) | pyngrok URL 자동 등록 |
+| 2PC (원격 PC) | 원격 PC가 등록 → `engineRegistryService` 갱신 | 원격 PC IP/포트 또는 ngrok URL |
+
+## FE 관련 메모
+
+FE는 이 결정에서 `DATA_ENGINE_URL`을 직접 사용하지 않음.
+FE가 인지해야 하는 것:
+
+- EEG 스트림은 항상 BE Socket.io 경유로 수신됨 (`use-signal.ts`)
+- 2PC 확장 시 FE 코드 변경 없음 — BE가 엔진 URL 라우팅을 완전히 담당함
+- FE의 `NEXT_PUBLIC_API_URL` / `NEXT_PUBLIC_SOCKET_URL`은 BE 주소이며 Engine URL과 무관
+
+## References
+
+- `CLAUDE.md §1 실시간 데이터 파이프라인 흐름`
+- `CLAUDE.md §1 변경 이력 — feat/session-group-pairing`
+- [pyngrok 공식 문서](https://pyngrok.readthedocs.io/)
+- ADR-003 (dependency-cruiser — 02-processes 경계 규칙 포함)
+- Phase 16+ — 2PC NTP/LSL 동기화 별도 ADR 예정

--- a/docs/architecture/decisions/ADR-005-ci-advisory-transition.md
+++ b/docs/architecture/decisions/ADR-005-ci-advisory-transition.md
@@ -1,6 +1,6 @@
 # ADR-005: CI 게이트를 2주 advisory 기간 후 blocking으로 전환함
 
-- **Status**: Proposed
+- **Status**: Accepted
 - **Date**: 2026-04-18
 - **Applies to**: both repos (BE + FE)
 - **Deciders**: @gs07103
@@ -31,13 +31,10 @@ blocking 효과가 없음:
 1. `.github/workflows/commitlint.yml`의 `continue-on-error: true` → `false` 교체 PR
 2. GitHub repo Settings > Branch protection > Required status checks에 `commitlint` 추가
 
-> ⚠️ **Transition date 미박제 (작성 시점)**: Wave 2 머지가 완료되면 이 ADR을 편집하여
-> 실제 머지 날짜를 아래 `Transition date` 필드에 기입할 것.
-
 ## Transition date
 
-- **Wave 2 머지일**: TBD (Wave 2 머지 직후 이 ADR 편집하여 날짜 박제)
-- **Blocking 전환 기한**: Wave 2 머지일 + 14 days (D+14)
+- **Wave 2 머지일**: 2026-04-21 (BE PR #42 `fd57a31` create merge; FE PR #42 `daaf737` squash)
+- **Blocking 전환 기한**: 2026-05-05 (Wave 2 머지일 + 14 days)
 
 > FE 특이사항: FE는 6-step verify 파이프라인이 이미 적용됨 (PR #36).
 > commitlint는 Wave 5에서 새로 추가됨. advisory transition 규칙은 BE와 동일하게 적용됨.

--- a/docs/architecture/decisions/ADR-005-ci-advisory-transition.md
+++ b/docs/architecture/decisions/ADR-005-ci-advisory-transition.md
@@ -1,0 +1,137 @@
+# ADR-005: CI 게이트를 2주 advisory 기간 후 blocking으로 전환함
+
+- **Status**: Proposed
+- **Date**: 2026-04-18
+- **Applies to**: both repos (BE + FE)
+- **Deciders**: @gs07103
+- **Related**: ADR-003 (dependency-cruiser), ADR-001 (번호 FSD 레이어)
+
+## Context
+
+Phase 15에서 두 레포에 신규 CI 게이트가 추가됨:
+
+- **commitlint**: Conventional Commits 형식 검증 (`wagoid/commitlint-github-action@v6`)
+- **dependency-cruiser**: FSD 레이어 경계 검사 (`npm run depcruise`)
+
+두 레포 모두 운영 중(production traffic)이며, 기존 커밋·PR에서
+Conventional Commits 위반이나 FSD 경계 위반이 이미 있을 수 있음.
+이 상태에서 즉시 blocking 전환하면 모든 PR이 차단될 위험이 있음.
+
+따라서 2주(14일) advisory 기간을 두어 기존 위반 baseline을 정리한 후
+blocking으로 전환하는 점진적 정책이 필요함.
+
+## Decision
+
+신규 CI 게이트(`commitlint`, `depcruise`)는 `continue-on-error: true`(advisory)로
+시작하여, **Phase 15 Wave 2 머지일 + 14일**에 blocking으로 전환함.
+
+blocking 전환 시 **두 단계를 모두 수행해야 함** — 어느 한 단계만 수행하면
+blocking 효과가 없음:
+
+1. `.github/workflows/commitlint.yml`의 `continue-on-error: true` → `false` 교체 PR
+2. GitHub repo Settings > Branch protection > Required status checks에 `commitlint` 추가
+
+> ⚠️ **Transition date 미박제 (작성 시점)**: Wave 2 머지가 완료되면 이 ADR을 편집하여
+> 실제 머지 날짜를 아래 `Transition date` 필드에 기입할 것.
+
+## Transition date
+
+- **Wave 2 머지일**: TBD (Wave 2 머지 직후 이 ADR 편집하여 날짜 박제)
+- **Blocking 전환 기한**: Wave 2 머지일 + 14 days (D+14)
+
+> FE 특이사항: FE는 6-step verify 파이프라인이 이미 적용됨 (PR #36).
+> commitlint는 Wave 5에서 새로 추가됨. advisory transition 규칙은 BE와 동일하게 적용됨.
+> Transition date는 BE Wave 2 머지일과 동기화함 (14일 기산점 통일).
+
+## Alternatives considered
+
+### Option A: 즉시 blocking
+
+신규 게이트를 처음부터 blocking으로 적용함.
+
+**Trade-offs**: 표준과의 최단 시간 정렬. 그러나 기존 위반 baseline이 정리되지 않은
+운영 레포에서는 모든 PR이 차단되어 개발 흐름이 중단될 위험이 있음.
+
+**Rejected because**: 운영 레포 안정성 우선. 위반 baseline 정리 유예가 필요함.
+
+### Option B: advisory 기간 없이 경고만
+
+`continue-on-error: true` 상태를 영구 유지하여 위반을 경고만 표시함.
+
+**Trade-offs**: 개발 흐름 중단 없음. 그러나 게이트가 실질적 강제력이 없으면
+시간이 지나도 위반이 축적될 뿐임.
+
+**Rejected because**: advisory는 임시 유예이고, D+14일에 반드시 blocking으로 전환해야 함.
+영구 advisory는 도구 도입 목적을 무력화함.
+
+### Option C (selected): 2주 advisory → blocking
+
+**Selected**: 기존 위반 정리 유예 + 명확한 전환 기한 + 두 단계 수동 체크리스트.
+
+## Consequences
+
+**더 쉬워지는 것:**
+
+- 기존 커밋·PR 영향 없이 신규 게이트를 도입할 수 있음
+- 2주 동안 위반 카운트를 모니터링하며 기존 위반을 점진적으로 정리 가능함
+- D+14일 이후 모든 PR에서 Conventional Commits + FSD 경계 자동 강제됨
+
+**더 어려워지는 것:**
+
+- 전환 기한(D+14일)을 놓치면 advisory가 영구화될 위험이 있음.
+  아래 "Mandatory transition steps"의 두 단계를 반드시 수행해야 함
+
+**기술 부채:**
+
+- D+14일에 수동으로 두 단계 전환 작업 필요함.
+  캘린더 알림 또는 GitHub issue로 추적 권장
+
+## Mandatory transition steps (D+14일)
+
+두 단계 **모두** 수행해야 blocking이 실제로 작동함.
+step만 바꾸면 GitHub Actions job은 green이지만, required status check 미등록이면
+PR 머지 차단 효과가 없음.
+
+### Step 1: workflow yml 수정 PR
+
+```yaml
+# .github/workflows/commitlint.yml
+# 변경 전:
+- name: Lint commit messages
+  uses: wagoid/commitlint-github-action@v6
+  continue-on-error: true   # ← 이 줄 제거 또는 false로 변경
+
+# 변경 후:
+- name: Lint commit messages
+  uses: wagoid/commitlint-github-action@v6
+  # continue-on-error 없음 → 기본값 false (blocking)
+```
+
+### Step 2: GitHub Branch protection 등록
+
+```text
+Repository Settings
+  → Branches
+  → Branch protection rules
+  → main (또는 dev) 규칙 선택
+  → Required status checks
+  → Search "commitlint"
+  → 체크박스 활성화 → Save changes
+```
+
+> **두 단계 중 하나라도 누락하면 blocking 효과 없음.**
+
+## Implementation notes
+
+- BE: `.github/workflows/commitlint.yml` — `wagoid/commitlint-github-action@v6`
+- FE: 동일 구성 (Wave 5에서 추가)
+- advisory 기간 모니터링: `commitDepth: 1` (PR의 마지막 커밋만 검증, 과거 커밋 무시)
+- depcruise advisory: `.github/workflows/ci.yml`의 Architecture step에
+  `continue-on-error: true` 동일하게 적용
+
+## References
+
+- [wagoid/commitlint-github-action@v6](https://github.com/wagoid/commitlint-github-action)
+- ADR-003 (dependency-cruiser advisory step 포함)
+- PLAN.md § Wave 2 — `commitlint.yml` 신규, CI 6-step 확장
+- PLAN.md § 아키텍처 결정 표 — ADR-005 설명 (F2 High 반영)

--- a/docs/architecture/decisions/_ADR-template.md
+++ b/docs/architecture/decisions/_ADR-template.md
@@ -1,0 +1,77 @@
+# ADR-NNN: <결정 사항을 한 문장으로 기술>
+
+<!-- ⚠️ 이 파일을 수정하지 말 것. 복제하여 ADR-NNN-<slug>.md로 저장할 것.
+     언더스코어(_) 제거 후 사용함. Draft PR을 열고 Status: Proposed로 시작함.
+     main 머지 시 Status가 Accepted로 전환되며 이 파일은 append-only가 됨.
+     (documentation.md § Append-only rule 참조) -->
+
+---
+
+- **Status**: Proposed
+- **Date**: YYYY-MM-DD
+- **Applies to**: BE / FE / both repos
+- **Deciders**: @github-handle
+- **Related**: RFC-NNN (해당 시), ADR-NNN (대체 시)
+
+## Context
+
+이 결정이 해결하는 문제를 기술함. 구체적인 근거(측정값, 인시던트, 라이브러리 버전
+불일치, 규제 요건)를 제시함. 날짜, PR 번호, 이슈 번호를 인용함. 독자가
+"왜 지금인가?"를 물을 수 없을 만큼 충분한 배경을 제공해야 함.
+
+## Decision
+
+한두 문장으로 기술함. 결정 내용을 평이한 언어로 서술함. 이 문서의 나머지 부분은
+이 결정을 뒷받침하기 위해 존재함.
+
+> 예시: "Redis를 분산 세션 캐시로 사용함. 프로세스 내부 인메모리 캐시는 제거함."
+
+## Alternatives considered
+
+검토한 모든 선택지를 나열함(현상 유지 포함).
+각 선택지는 한 줄 설명 + 트레이드오프 + 기각 이유를 포함함.
+
+### Option A: <짧은 이름>
+
+간략히 기술함.
+
+**Trade-offs**: 장단점.
+
+**Rejected because**: 기각의 가장 강력한 이유 한 가지.
+
+### Option B: <짧은 이름>
+
+...
+
+### Option C (status quo): 현재 구현 유지
+
+...
+
+## Consequences
+
+이 결정 이후 **더 쉬워지는** 것:
+
+- ...
+
+이 결정 이후 **더 어려워지는** 것:
+
+- ...
+
+새로 발생하는 **기술 부채** (모든 ADR은 일정 부채를 수반함. 명시적으로 기록함):
+
+- ...
+
+## Implementation notes (optional)
+
+이 결정을 구현하는 코드 포인터를 간략히 기술함. 상세 통합 지침은 PR 설명이나
+FR 파일에 작성함.
+
+- 진입점: `src/...`
+- 설정: env 변수 `X_*`
+- 마이그레이션 계획: <링크>, <기한>
+
+## References
+
+- RFC-NNN (해당 시)
+- 외부 문서, 논문, 블로그 포스트
+- 관련 ADR: ADR-NNN, ADR-NNN

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,0 +1,150 @@
+# Architecture Overview — System Context (C4 Level 1, FE perspective)
+
+> **FE 관점의 시스템 컨텍스트 다이어그램.** 누가 시스템을 사용하고,
+> 어떤 외부 시스템과 통신하는지를 보여줌. FE(Next.js App Router)가 중심이며,
+> BE·Python Engine·인프라와의 통신 경계를 기술함.
+
+## One-line description
+
+Mind Signal은 Emotiv EEG 헤드셋으로 피실험자의 뇌파를 실시간 수집·분석하여
+연구자(Operator)에게 라이브 시각화 및 AI 분석 결과를 제공하는 뇌-컴퓨터 인터페이스 연구 플랫폼임.
+
+## System context diagram
+
+```mermaid
+%% C4 Level 1 — System Context (FE perspective)
+flowchart TB
+    subgraph UserDevices["사용자 디바이스"]
+        Operator(["Operator\n(연구원, PC 브라우저)"])
+        Subject(["Subject\n(피실험자, 모바일 브라우저)"])
+        Headset(["Emotiv 헤드셋\n(BLE/USB, Operator PC에 연결)"])
+    end
+
+    FE[["Mind Signal Frontend\n(Next.js 16 App Router + React 19)\nVercel 배포"]]
+
+    subgraph BackendInfra["백엔드 인프라"]
+        BE[["Mind Signal Backend\n(Node.js / Express + TS)\nHeroku 배포"]]
+        Redis[("Redis\n(Docker 6379)")]
+        MongoDB[("MongoDB\n(Atlas)")]
+    end
+
+    subgraph LocalPC["Operator PC (로컬)"]
+        EmotivApp["Emotiv App\n(로컬 실행 필수)"]
+        PythonEngine["Python core.main\n(세션별 on-demand spawn)"]
+        Headset -->|"BLE / USB"| EmotivApp
+        EmotivApp -->|"Cortex WebSocket"| PythonEngine
+    end
+
+    GoogleOAuth["Google OAuth 2.0"]
+    KakaoOAuth["Kakao OAuth 2.0"]
+
+    Operator -->|"세션 생성·모니터링\n(PC 브라우저)"| FE
+    Subject -->|"QR 스캔·동의서 제출\n(모바일 브라우저)"| FE
+
+    FE -->|"HTTPS REST\n(Axios + JWT interceptor)"| BE
+    BE -->|"Socket.io\n실시간 EEG 스트림"| FE
+
+    PythonEngine -->|"Redis publish\nmind-signal:{groupId}:subject:{subjectIndex}"| Redis
+    Redis -->|"subscribe"| BE
+    BE -->|"HTTP/WS (engineRegistryService)\npyngrok 자동 등록 모델"| PythonEngine
+    BE -->|"read / write"| MongoDB
+
+    BE -->|"OAuth 토큰 검증"| GoogleOAuth
+    BE -->|"OAuth 토큰 검증"| KakaoOAuth
+
+    classDef person fill:#08427B,stroke:#052E56,color:#fff
+    classDef feSystem fill:#1168BD,stroke:#0B4884,color:#fff
+    classDef beSystem fill:#2D6A4F,stroke:#1B4332,color:#fff
+    classDef external fill:#666,stroke:#444,color:#fff
+    classDef infra fill:#6B6B6B,stroke:#4A4A4A,color:#fff
+    classDef local fill:#E8F5E9,stroke:#2D6A4F,color:#222
+
+    class Operator,Subject person
+    class FE feSystem
+    class BE beSystem
+    class Redis,MongoDB infra
+    class GoogleOAuth,KakaoOAuth,EmotivApp external
+    class PythonEngine external
+    class Headset infra
+```
+
+## Actors
+
+| Actor | Type | 역할 |
+|---|---|---|
+| `Operator` | Person | PC 브라우저에서 실험을 관리하는 연구원. QR 생성, EEG 라이브 차트(Recharts) 모니터링, 분석 결과 확인함 |
+| `Subject` | Person | 모바일 브라우저로 QR 스캔하여 참여하는 피실험자. EEG 측정 대상임 |
+
+## External systems (FE 관점)
+
+| System | Direction | Purpose |
+|---|---|---|
+| `Mind Signal Backend` | bidirectional | HTTPS REST(JWT 인증) + Socket.io 실시간 EEG 스트림. FE의 주요 통신 대상 |
+| `Google OAuth 2.0` | outbound (via BE) | Operator / Subject 소셜 로그인 — OAuth 토큰 검증은 BE에서 처리됨 |
+| `Kakao OAuth 2.0` | outbound (via BE) | 동일 — FE는 리다이렉트 URL 처리만 담당 |
+| `Vercel` | — | Next.js App Router 프론트엔드 호스팅 플랫폼 |
+| `EMOTIV 헤드셋` | — (Operator 기기에 연결) | FE와 직접 통신 없음. Operator PC에서 Emotiv App → Python Engine → Redis → BE → FE 경로 |
+
+## Key data flows (FE 관점)
+
+| Flow | Description |
+|---|---|
+| **EEG 실시간 시각화** | BE Socket.io → FE `useSignal` hook → Recharts 바 차트 업데이트 (1초 주기) |
+| **세션 생성** | Operator FE `POST /sessions` → BE → QR 코드 응답 → FE 표시 |
+| **Subject 페어링** | Subject FE QR 스캔 → `POST /sessions/:pairingToken/pair` → BE 상태 PAIRED → Socket.io 알림 → Operator FE 갱신 |
+| **소셜 로그인** | FE 리다이렉트 → Google/Kakao OAuth → BE 토큰 검증 → JWT 발급 → `localStorage['token']` 저장 |
+| **Zod 폼 검증** | FE 폼 제출 시 Zod 스키마 클라이언트 검증 → 통과 시 API 호출 |
+
+## FE 특유 아키텍처 포인트
+
+### React Compiler (Forget) 활성화
+- Next.js 16 App Router + React 19 + React Compiler 조합 사용 중.
+- `useMemo`/`useCallback` 수동 추가 금지 — Compiler가 자동 처리.
+
+### Server Components / Client Components 분리
+- 상태·이벤트·브라우저 API를 사용하는 컴포넌트는 `'use client'` 선언 필수.
+- SSR 안전 마운트 감지: `useSyncExternalStore` 사용.
+
+### Zod 폼 검증
+- 환경변수: `src/07-shared/config/config.ts`에서 Zod로 파싱.
+- 폼 입력: 클라이언트 Zod 스키마로 검증 후 API 호출.
+
+### MSW 테스트 모킹
+- Vitest + `@vitest/browser` 실브라우저 환경.
+- API 모킹: MSW(Mock Service Worker) 사용.
+- 141개 테스트 (Playwright browser mode, chromium).
+
+### Playwright E2E
+- `e2e/*.spec.ts` — auth, home, join, results 시나리오.
+- `playwright.config.ts`의 `webServer`로 `next dev` 자동 기동.
+
+### Socket.io 통신
+- BE와 양방향 실시간 통신. `src/05-features/signals/model/use-signal.ts` 경유.
+- 세션 상태 폴링: 3초 간격 (WebSocket fallback 아닌 추가 폴링).
+
+## FSD 레이어 구조 (번호 prefix)
+
+```text
+app/             ← 01-app: Next.js routes, Providers, root layout
+02-processes/    ← (reserved) multi-feature workflows
+03-pages/        ← page-level components
+04-widgets/      ← Navbar, Footer, SignalChart
+05-features/     ← auth, sessions, signals, chat-assistant
+06-entities/     ← (reserved) domain entity UI
+07-shared/       ← api, config, types, constants, utils
+```
+
+import 방향: 번호 높은 레이어 → 번호 낮은 레이어 (`07-shared`가 가장 높은 기반 레이어).
+경계 검사: `dependency-cruiser@^17.3.10` — `npm run depcruise` (ADR-003).
+
+## 2PC 확장 경계 (ADR-004, 정보성 참조)
+
+Python Engine 접근은 BE 측 `DATA_ENGINE_URL` env + `engineRegistryService`로 추상화됨.
+FE는 BE Socket.io 스트림만 수신하므로 2PC 확장 시 FE 코드 변경 없음.
+상세: `mind-signal-backend/docs/architecture/decisions/ADR-004-engine-url-abstraction.md`
+
+## What this diagram is NOT
+
+- C4 Level 2 Container Diagram이 아님 (`containers.md`에서 별도 기술)
+- 데이터 흐름도(DFD)가 아님 — 프로세스 간 데이터 이동은 `DFD.md`에서 기술
+- 프레임워크 상세(App Router 라우팅, Server Actions)는 Level 2 이하에서 기술함

--- a/docs/reports/README.md
+++ b/docs/reports/README.md
@@ -1,0 +1,96 @@
+# docs/reports/
+
+일회성 산출물 보관소. Lighthouse 성능 벤치마크, Playwright E2E 측정, React Compiler 마이그레이션
+분석, 컴포넌트 설계 PAAR, Next.js 버전 업그레이드 분석 결과를 여기에 보관함.
+
+> **"영속 지식" vs "일회성 산출물" 구분**
+>
+> - 설계 결정처럼 **계속 살아있는** 지식 → `docs/architecture/` 또는 `docs/requirements/`
+> - 특정 시점의 측정·검증·사건 분석처럼 **스냅샷으로 동결되는** 결과물 → 여기(reports/)
+
+---
+
+## 템플릿 선택 기준
+
+| 쓰려는 내용 | 사용할 템플릿 | 출력 파일 예시 |
+|---|---|---|
+| Lighthouse 성능 측정, Playwright 렌더링 타이밍, React 벤치마크 | `_spike-test-template.md` | `spike-test-2026-04-20-lighthouse-mobile-run.md` |
+| 라이브러리·프레임워크 비교, "X 채택" 결론 포함 (Next.js 버전, 번들러 등) | `_benchmark-template.md` | `benchmark-2026-04-20-react-compiler-migration.md` |
+| 외부 API·핵심 시스템 동작 방식 심층 분석 (EMOTIV Cortex SDK, Socket.io 등) | `_api-analysis-template.md` | `api-analysis-2026-04-20-emotiv-cortex-v3.md` |
+| 장애·CI 플레이크·회귀·E2E 불안정 등 사후 분석 | `_paar-template.md` | `paar-2026-04-20-playwright-flaky-join-spec.md` |
+
+템플릿 파일 자체(`_*.md`)는 작성 시점에 복사해서 사용함. 이 디렉토리에 바로 편집하지 말 것.
+
+---
+
+## 네이밍 규칙
+
+```text
+<type>-YYYY-MM-DD-<slug>.md
+```
+
+- **type**: `spike-test` / `benchmark` / `api-analysis` / `paar`
+- **날짜**: 문서 작성일이 아닌 **작업이 수행된 날짜** 기준
+- **slug**: 짧고 검색 가능한 kebab-case
+  - 좋은 예: `lighthouse-mobile-run`, `react-compiler-migration`, `playwright-join-e2e`
+  - 나쁜 예: `test1`, `분석결과`, `performance`
+
+---
+
+## Reports → ADR 연결 패턴
+
+벤치마크나 스파이크 테스트가 기술 결정으로 이어질 때:
+
+1. 측정 결과를 이 폴더에 report로 작성함 (수치·근거 포함)
+2. 그 결정을 `docs/architecture/decisions/ADR-NNN-<slug>.md`에 별도 기록함
+3. ADR 본문에 report 파일 링크 추가 — report가 증거, ADR이 결론
+
+**두 파일 모두 유지함.** report는 수치 트레일이고, ADR은 채택 사유임.
+
+---
+
+## PAAR (문제·행동·분석·결과) 사용 시점
+
+PAAR는 사후 분석 포맷임. 사용 대상:
+
+- 운영 장애 (Vercel 배포 실패, SSR hydration 오류 등)
+- CI 플레이크 원인 추적 (예: Playwright E2E `join.spec.ts` 타임아웃, Vitest 비결정적 실패)
+- React rendering 회귀 — React Compiler 활성화 후 예상치 못한 리렌더링
+- "무슨 일이 있었고 어떻게 막을까"가 보존할 가치가 있는 모든 상황
+
+PAAR는 **사후(reactive)** 보고서임. 나머지 세 가지(spike / benchmark / api-analysis)는 **사전(proactive)** 계획 작업임.
+
+---
+
+## git 추적 여부
+
+이 디렉토리는 **git 추적 대상** (팀 공유 지식).
+
+`.gitignore`에 `docs/reports/` 제외 항목이 없으면 기본으로 추적됨.
+작업 중 초안(`WIP-*.md`)은 커밋 전 파일명에서 `WIP-` 접두사를 제거할 것.
+
+---
+
+## 예시 파일 (작성 예정)
+
+- (작성 예정) `spike-test-2026-04-20-lighthouse-mobile-run.md` — Vercel 배포 후 모바일 Lighthouse 점수 측정 (LCP/CLS/FID)
+- (작성 예정) `benchmark-2026-04-20-react-compiler-migration.md` — React Compiler 활성화 전후 useMemo/useCallback 제거 범위 + bundle size 변화
+
+---
+
+## 템플릿 복사 방법
+
+```bash
+# 예: Lighthouse 스파이크 테스트 보고서 시작 시
+# (FE 레포 루트에서 실행함)
+cp ../templates-review/typescript-template/docs/reports/_spike-test-template.md \
+   docs/reports/spike-test-$(date +%Y-%m-%d)-<slug>.md
+```
+
+> 템플릿 원본 위치: `Team-project/templates-review/typescript-template/docs/reports/_*.md`
+>
+> 사용 가능한 템플릿:
+> - `_api-analysis-template.md`
+> - `_benchmark-template.md`
+> - `_paar-template.md`
+> - `_spike-test-template.md`

--- a/docs/requirements/RTM.md
+++ b/docs/requirements/RTM.md
@@ -1,0 +1,41 @@
+# Requirements Traceability Matrix
+
+> 모든 기능 요구사항(FR)을 아티팩트에 연결하는 단일 소스임.
+> GitHub 이슈, 아키텍처 결정(ADR), 구현 코드, 테스트, 현재 상태를 하나의 테이블로 추적함.
+
+## 사용 방법
+
+- **행 추가**: 새 FR 파일을 `docs/requirements/FR-XX-<slug>.md`로 작성할 때 동시에 이 테이블에 행을 추가함
+- **행 갱신**: FR을 구현·변경하는 PR과 같은 PR에서 해당 행을 업데이트함
+- **행 삭제 금지**: FR이 폐기되면 Status를 `Deprecated`로 변경하고 FR 파일에 사유를 기록함
+- **비기능 요구사항(NFR)**: 하단의 별도 섹션에 기록함
+- PR 머지 시 해당 FR의 Status 컬럼을 `Done`으로 업데이트함
+
+## Status 값
+
+| 값 | 의미 |
+|---|---|
+| `Draft` | FR 파일 존재, AC 미확정 |
+| `Design` | AC 합의됨, ADR 작성 중 |
+| `Implementing` | PR 오픈, 테스트 추가 중 |
+| `Done` | 머지 완료, 테스트 통과, RTM 행 완성 |
+| `Deprecated` | 더 이상 스코프 외 — 이력 보존을 위해 행 유지 |
+
+---
+
+## Functional Requirements
+
+<!-- 첫 번째 실제 FR을 추가할 때 아래 예시 행을 삭제할 것. -->
+<!-- 새 FR 작성: docs/requirements/_FR-template.md 복제 → FR-XX-<slug>.md로 저장 -->
+
+| FR ID | Title | Source | Implementation | Tests | PR | Status |
+|---|---|---|---|---|---|---|
+| FR-00 | (예시) QR 세션 참여 | #0 | `src/05-features/sessions/ui/join-page.tsx` | `src/05-features/sessions/join.test.tsx` | — | Draft |
+
+---
+
+## Non-Functional Requirements
+
+| NFR ID | Summary | Target | Measurement | Owner | Status |
+|---|---|---|---|---|---|
+| NFR-00 | (예시) FE 초기 로드 성능 | LCP < 2.5 s | Lighthouse CI (`docs/reports/benchmark-YYYY-MM-DD-lcp.md`) | @gs07103 | Draft |

--- a/docs/requirements/_FR-template.md
+++ b/docs/requirements/_FR-template.md
@@ -1,0 +1,132 @@
+# FR-XX: <한 줄 명령형 제목>
+
+<!-- ⚠️ 이 파일을 수정하지 말 것. 복제하여 FR-XX-<slug>.md로 저장할 것.
+     언더스코어(_) 제거 후 사용함. 모든 섹션을 채운 뒤 RTM.md에 행을 추가함.
+     같은 PR에서 FR 파일 + RTM 행 업데이트를 함께 처리함. -->
+
+---
+
+## Metadata
+
+- **FR ID**: FR-XX
+- **Status**: ([RTM Status 값](./RTM.md#status-값) 참조)
+- **Priority**: P0 (필수) / P1 (중요) / P2 (선택)
+- **GitHub Issue**: #NNN
+- **Related ADRs**: ADR-NNN (해당 시)
+- **Owner**: @gs07103
+- **Created**: YYYY-MM-DD
+
+## Source (요구사항 출처)
+
+이 FR이 어디서 왔는지 명시함 — PRD 섹션, GitHub 이슈, 팀 회의 날짜 등.
+
+- PRD: `.plans/PRD.md §N`
+- 이슈: #NNN
+- 회의: YYYY-MM-DD 팀 회의 결정사항
+
+## User story
+
+As a **<actor>** (예: Operator, Subject), I want **<capability>**, so that **<outcome>**.
+
+## Trigger
+
+무엇이 이 기능을 시작하는가? HTTP 요청, 크론, 사용자 클릭, 외부 웹훅?
+
+- 예: Operator가 FE 대시보드에서 "세션 시작" 버튼 클릭
+
+## Inputs
+
+| Name | Type (TypeScript / Zod) | Source | Constraints |
+|---|---|---|---|
+| `groupId` | `string` (z.string().regex(/^[a-f0-9]{24}$/)) | Form submit | MongoDB ObjectId 형식 |
+
+## Outputs
+
+| Name | Type | Consumer | Notes |
+|---|---|---|---|
+| `SessionDto` | `z.infer<typeof SessionSchema>` | FE UI 렌더 | `src/07-shared/types/index.ts`에 정의됨 |
+
+## Preconditions
+
+**실행 전** 무엇이 참이어야 하는가? 이것이 코드에서 guard clause 또는
+미들웨어 검사로 구현됨. 각 전제조건을 강제하는 함수/파일을 명시함.
+
+- [ ] 사용자가 인증됨 (`src/07-shared/api/base.ts`의 JWT interceptor가 토큰 주입)
+- [ ] 입력이 Zod 스키마를 통과함 (클라이언트 Zod 검증 후 API 호출)
+
+## Postconditions
+
+**완료 후** 무엇이 참이어야 하는가? 이것이 테스트의 assertions가 됨.
+
+- [ ] BE API 응답이 기대 스키마와 일치함
+- [ ] FE 화면 상태가 정상적으로 갱신됨
+- [ ] 동일 입력으로 반복 호출 시 부작용 없음 (idempotency 요구 시 명시)
+
+## Structured logic
+
+**구조화된 영어**로 흐름을 기술함 (`IF … THEN … ELSE`, `FOR EACH`, `WHILE`, `RETURN`).
+자연어 모호성 없이 기술함. LLM이 이 명세에서 컴파일 가능한 함수를 생성할 수 있어야 함.
+
+```
+BEGIN FR-XX
+  VALIDATE input via XxxSchema (실패 시 에러 메시지 표시, API 호출 금지)
+  CALL API endpoint (인증 토큰 자동 주입)
+  IF response.status IS 200/201 THEN
+    UPDATE FE state
+    NAVIGATE to result page (해당 시)
+  ELSE IF response.status IS 401 THEN
+    REDIRECT to login page
+  ELSE
+    DISPLAY error message from response body
+  END IF
+END FR-XX
+```
+
+## Decision table
+
+**3개 이상의 상호작용 조건이 있을 때만 이 섹션을 포함함.**
+조건 1개 = 행 1개, 규칙(Rule) 1개 = 열 1개. Y / N / — (무관).
+
+| Conditions | R1 | R2 | R3 |
+|---|---|---|---|
+| 인증 토큰 존재 | N | Y | Y |
+| API 응답 성공 | — | N | Y |
+| **Actions** | | | |
+| 로그인 페이지 리다이렉트 | X | | |
+| 에러 메시지 표시 | | X | |
+| FE 상태 갱신 + 페이지 이동 | | | X |
+
+**테스트 커버리지 규칙**: Rule 열 1개 = 테스트 1개. 모든 Rule 열은 테스트 대상임.
+
+## Exception handling
+
+- **네트워크 오류**: Axios interceptor가 자동 재시도 또는 에러 상태 표시
+- **Zod 검증 실패**: 폼 인라인 에러 메시지 표시, API 호출 금지
+- **401 Unauthorized**: 로그인 페이지로 리다이렉트, localStorage 토큰 제거
+
+## Test plan
+
+| Level | Scenario | File |
+|---|---|---|
+| unit | happy path | `src/05-features/xxx/xxx.test.tsx` |
+| unit | decision-table Rule별 (R1 … RN) | `src/05-features/xxx/rules.test.tsx` |
+| e2e | 전체 HTTP round-trip | `e2e/fr-xx.spec.ts` (해당 시) |
+
+## Dependencies
+
+- 선행 완료 필요 FR: FR-XX
+- 의존 ADR: ADR-NNN
+- 의존 BE API: `POST /api/xxx` (BE 측 구현 완료 필요)
+
+## Traceability
+
+- **Implementation files**: `src/...`
+- **Tests**: `src/.../xxx.test.tsx`
+- **Related ADRs**: ADR-NNN
+- **RTM row**: [RTM.md](./RTM.md) FR-XX 행
+
+## Notes
+
+<!-- 해결된 질문은 위 섹션의 명세로 편입함. -->
+
+- [ ] 미결 질문이나 불확실한 전제조건을 여기에 기록함

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,8 @@
       },
       "devDependencies": {
         "@chromatic-com/storybook": "^5.0.0",
+        "@commitlint/cli": "^20.5.0",
+        "@commitlint/config-conventional": "^20.5.0",
         "@playwright/test": "^1.58.2",
         "@storybook/addon-a11y": "^10.2.6",
         "@storybook/addon-docs": "^10.2.6",
@@ -406,6 +408,349 @@
       },
       "peerDependencies": {
         "storybook": "^0.0.0-0 || ^10.1.0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0"
+      }
+    },
+    "node_modules/@commitlint/cli": {
+      "version": "20.5.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-20.5.0.tgz",
+      "integrity": "sha512-yNkyN/tuKTJS3wdVfsZ2tXDM4G4Gi7z+jW54Cki8N8tZqwKBltbIvUUrSbT4hz1bhW/h0CdR+5sCSpXD+wMKaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/format": "^20.5.0",
+        "@commitlint/lint": "^20.5.0",
+        "@commitlint/load": "^20.5.0",
+        "@commitlint/read": "^20.5.0",
+        "@commitlint/types": "^20.5.0",
+        "tinyexec": "^1.0.0",
+        "yargs": "^17.0.0"
+      },
+      "bin": {
+        "commitlint": "cli.js"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/config-conventional": {
+      "version": "20.5.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-20.5.0.tgz",
+      "integrity": "sha512-t3Ni88rFw1XMa4nZHgOKJ8fIAT9M2j5TnKyTqJzsxea7FUetlNdYFus9dz+MhIRZmc16P0PPyEfh6X2d/qw8SA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^20.5.0",
+        "conventional-changelog-conventionalcommits": "^9.2.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/config-validator": {
+      "version": "20.5.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-20.5.0.tgz",
+      "integrity": "sha512-T/Uh6iJUzyx7j35GmHWdIiGRQB+ouZDk0pwAaYq4SXgB54KZhFdJ0vYmxiW6AMYICTIWuyMxDBl1jK74oFp/Gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^20.5.0",
+        "ajv": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/config-validator/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@commitlint/config-validator/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@commitlint/ensure": {
+      "version": "20.5.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-20.5.0.tgz",
+      "integrity": "sha512-IpHqAUesBeW1EDDdjzJeaOxU9tnogLAyXLRBn03SHlj1SGENn2JGZqSWGkFvBJkJzfXAuCNtsoYzax+ZPS+puw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^20.5.0",
+        "lodash.camelcase": "^4.3.0",
+        "lodash.kebabcase": "^4.1.1",
+        "lodash.snakecase": "^4.1.1",
+        "lodash.startcase": "^4.4.0",
+        "lodash.upperfirst": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/execute-rule": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-20.0.0.tgz",
+      "integrity": "sha512-xyCoOShoPuPL44gVa+5EdZsBVao/pNzpQhkzq3RdtlFdKZtjWcLlUFQHSWBuhk5utKYykeJPSz2i8ABHQA+ZZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/format": {
+      "version": "20.5.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-20.5.0.tgz",
+      "integrity": "sha512-TI9EwFU/qZWSK7a5qyXMpKPPv3qta7FO4tKW+Wt2al7sgMbLWTsAcDpX1cU8k16TRdsiiet9aOw0zpvRXNJu7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^20.5.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/is-ignored": {
+      "version": "20.5.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-20.5.0.tgz",
+      "integrity": "sha512-JWLarAsurHJhPozbuAH6GbP4p/hdOCoqS9zJMfqwswne+/GPs5V0+rrsfOkP68Y8PSLphwtFXV0EzJ+GTXTTGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^20.5.0",
+        "semver": "^7.6.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/is-ignored/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@commitlint/lint": {
+      "version": "20.5.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-20.5.0.tgz",
+      "integrity": "sha512-jiM3hNUdu04jFBf1VgPdjtIPvbuVfDTBAc6L98AWcoLjF5sYqkulBHBzlVWll4rMF1T5zeQFB6r//a+s+BBKlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/is-ignored": "^20.5.0",
+        "@commitlint/parse": "^20.5.0",
+        "@commitlint/rules": "^20.5.0",
+        "@commitlint/types": "^20.5.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/load": {
+      "version": "20.5.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-20.5.0.tgz",
+      "integrity": "sha512-sLhhYTL/KxeOTZjjabKDhwidGZan84XKK1+XFkwDYL/4883kIajcz/dZFAhBJmZPtL8+nBx6bnkzA95YxPeDPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/config-validator": "^20.5.0",
+        "@commitlint/execute-rule": "^20.0.0",
+        "@commitlint/resolve-extends": "^20.5.0",
+        "@commitlint/types": "^20.5.0",
+        "cosmiconfig": "^9.0.1",
+        "cosmiconfig-typescript-loader": "^6.1.0",
+        "is-plain-obj": "^4.1.0",
+        "lodash.mergewith": "^4.6.2",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/message": {
+      "version": "20.4.3",
+      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-20.4.3.tgz",
+      "integrity": "sha512-6akwCYrzcrFcTYz9GyUaWlhisY4lmQ3KvrnabmhoeAV8nRH4dXJAh4+EUQ3uArtxxKQkvxJS78hNX2EU3USgxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/parse": {
+      "version": "20.5.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-20.5.0.tgz",
+      "integrity": "sha512-SeKWHBMk7YOTnnEWUhx+d1a9vHsjjuo6Uo1xRfPNfeY4bdYFasCH1dDpAv13Lyn+dDPOels+jP6D2GRZqzc5fA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^20.5.0",
+        "conventional-changelog-angular": "^8.2.0",
+        "conventional-commits-parser": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/read": {
+      "version": "20.5.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-20.5.0.tgz",
+      "integrity": "sha512-JDEIJ2+GnWpK8QqwfmW7O42h0aycJEWNqcdkJnyzLD11nf9dW2dWLTVEa8Wtlo4IZFGLPATjR5neA5QlOvIH1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/top-level": "^20.4.3",
+        "@commitlint/types": "^20.5.0",
+        "git-raw-commits": "^5.0.0",
+        "minimist": "^1.2.8",
+        "tinyexec": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/resolve-extends": {
+      "version": "20.5.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-20.5.0.tgz",
+      "integrity": "sha512-3SHPWUW2v0tyspCTcfSsYml0gses92l6TlogwzvM2cbxDgmhSRc+fldDjvGkCXJrjSM87BBaWYTPWwwyASZRrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/config-validator": "^20.5.0",
+        "@commitlint/types": "^20.5.0",
+        "global-directory": "^4.0.1",
+        "import-meta-resolve": "^4.0.0",
+        "lodash.mergewith": "^4.6.2",
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/resolve-extends/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@commitlint/rules": {
+      "version": "20.5.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-20.5.0.tgz",
+      "integrity": "sha512-5NdQXQEdnDPT5pK8O39ZA7HohzPRHEsDGU23cyVCNPQy4WegAbAwrQk3nIu7p2sl3dutPk8RZd91yKTrMTnRkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/ensure": "^20.5.0",
+        "@commitlint/message": "^20.4.3",
+        "@commitlint/to-lines": "^20.0.0",
+        "@commitlint/types": "^20.5.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/to-lines": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-20.0.0.tgz",
+      "integrity": "sha512-2l9gmwiCRqZNWgV+pX1X7z4yP0b3ex/86UmUFgoRt672Ez6cAM2lOQeHFRUTuE6sPpi8XBCGnd8Kh3bMoyHwJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/top-level": {
+      "version": "20.4.3",
+      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-20.4.3.tgz",
+      "integrity": "sha512-qD9xfP6dFg5jQ3NMrOhG0/w5y3bBUsVGyJvXxdWEwBm8hyx4WOk3kKXw28T5czBYvyeCVJgJJ6aoJZUWDpaacQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/types": {
+      "version": "20.5.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-20.5.0.tgz",
+      "integrity": "sha512-ZJoS8oSq2CAZEpc/YI9SulLrdiIyXeHb/OGqGrkUP6Q7YV+0ouNAa7GjqRdXeQPncHQIDz/jbCTlHScvYvO/gA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "conventional-commits-parser": "^6.3.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@conventional-changelog/git-client": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@conventional-changelog/git-client/-/git-client-2.7.0.tgz",
+      "integrity": "sha512-j7A8/LBEQ+3rugMzPXoKYzyUPpw/0CBQCyvtTR7Lmu4olG4yRC/Tfkq79Mr3yuPs0SUitlO2HwGP3gitMJnRFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@simple-libs/child-process-utils": "^1.0.0",
+        "@simple-libs/stream-utils": "^1.2.0",
+        "semver": "^7.5.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "conventional-commits-filter": "^5.0.0",
+        "conventional-commits-parser": "^6.4.0"
+      },
+      "peerDependenciesMeta": {
+        "conventional-commits-filter": {
+          "optional": true
+        },
+        "conventional-commits-parser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@conventional-changelog/git-client/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@emnapi/core": {
@@ -2605,6 +2950,35 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@simple-libs/child-process-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@simple-libs/child-process-utils/-/child-process-utils-1.0.2.tgz",
+      "integrity": "sha512-/4R8QKnd/8agJynkNdJmNw2MBxuFTRcNFnE5Sg/G+jkSsV8/UBgULMzhizWWW42p8L5H7flImV2ATi79Ove2Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@simple-libs/stream-utils": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/dangreen"
+      }
+    },
+    "node_modules/@simple-libs/stream-utils": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@simple-libs/stream-utils/-/stream-utils-1.2.0.tgz",
+      "integrity": "sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/dangreen"
+      }
+    },
     "node_modules/@socket.io/component-emitter": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
@@ -4521,6 +4895,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/array-ify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
+      "integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/array-includes": {
       "version": "3.1.9",
       "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
@@ -5177,12 +5558,66 @@
         "node": ">=20"
       }
     },
+    "node_modules/compare-func": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
+      "integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-ify": "^1.0.0",
+        "dot-prop": "^5.1.0"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/conventional-changelog-angular": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.3.1.tgz",
+      "integrity": "sha512-6gfI3otXK5Ph5DfCOI1dblr+kN3FAm5a97hYoQkqNZxOaYa5WKfXH+AnpsmS+iUH2mgVC2Cg2Qw9m5OKcmNrIg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "compare-func": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-changelog-conventionalcommits": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.3.1.tgz",
+      "integrity": "sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "compare-func": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-commits-parser": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
+      "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@simple-libs/stream-utils": "^1.2.0",
+        "meow": "^13.0.0"
+      },
+      "bin": {
+        "conventional-commits-parser": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -5203,6 +5638,51 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cosmiconfig": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
+      "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.1",
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/cosmiconfig-typescript-loader": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-6.3.0.tgz",
+      "integrity": "sha512-Akr82WH1Wfqatyiqpj8HDkO2o2KmJRu1FhKfSNJP3K4IdXwHfEyL7MOb62i1AGQVLtIQM+iCE9CGOtrfhR+mmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jiti": "2.6.1"
+      },
+      "engines": {
+        "node": ">=v18"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "cosmiconfig": ">=9",
+        "typescript": ">=5"
       }
     },
     "node_modules/cross-spawn": {
@@ -5667,6 +6147,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dot-prop": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+      "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-obj": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -5767,6 +6260,26 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
       }
     },
     "node_modules/es-abstract": {
@@ -6550,6 +7063,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -6861,6 +7391,23 @@
       },
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/git-raw-commits": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-5.0.1.tgz",
+      "integrity": "sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@conventional-changelog/git-client": "^2.6.0",
+        "meow": "^13.0.0"
+      },
+      "bin": {
+        "git-raw-commits": "src/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/glob": {
@@ -7190,6 +7737,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -7271,6 +7829,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-async-function": {
       "version": "2.1.1",
@@ -7593,10 +8158,33 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-path-inside": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
       "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7901,6 +8489,13 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true,
       "license": "MIT"
     },
@@ -8275,6 +8870,13 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -8291,10 +8893,52 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.kebabcase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
+      "integrity": "sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.snakecase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+      "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.startcase": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
+      "integrity": "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.upperfirst": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz",
+      "integrity": "sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==",
       "dev": true,
       "license": "MIT"
     },
@@ -8405,6 +9049,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/meow": {
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
+      "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/merge2": {
@@ -8972,6 +9629,25 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/path-exists": {
@@ -9587,6 +10263,16 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "format:check": "prettier --check \"src/**/*.{ts,tsx,md}\"",
     "typecheck": "tsc --noEmit",
     "depcruise": "depcruise src --config .dependency-cruiser.cjs",
-    "verify": "npm run format:check && npm run typecheck && npm run depcruise && npm run lint && npm run test && npm run build"
+    "verify": "npm run format:check && npm run typecheck && npm run depcruise && npm run lint && npm run test && npm run build",
+    "commitlint": "commitlint --from=HEAD~1 --to=HEAD --verbose"
   },
   "dependencies": {
     "@radix-ui/react-label": "^2.1.8",
@@ -43,6 +44,8 @@
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^5.0.0",
+    "@commitlint/cli": "^20.5.0",
+    "@commitlint/config-conventional": "^20.5.0",
     "@playwright/test": "^1.58.2",
     "@storybook/addon-a11y": "^10.2.6",
     "@storybook/addon-docs": "^10.2.6",


### PR DESCRIPTION
## Summary
Phase 15 Template Intent Retrofit (Wave 4-6) + ADR-005 Accepted + Transition date 박제 + pre-push hook 범위 버그 수정 main 반영.

### 포함 커밋 (dev HEAD `b8dab47`)
- `daaf737` Phase 15 Wave 4-6 squash (PR #42, 8 commits + CR fix 4)
- `177e5d2` docs(architecture): accept ADR-005 and stamp transition date 2026-04-21
- `3c9e9d2` fix(hooks): narrow pre-push commitlint check to push range only
- `b8dab47` Merge PR #48

## Verify (dev HEAD 실측, 2026-04-21~22)
- `npm run verify` 6-step PASS (204 tests / 21 files)
- Playwright E2E: 32 PASS / 20 FAIL / 2 SKIP — **회귀 아님**, Phase 14 SEQUENTIAL UX 누적 test rot

## Known issues
- FE E2E 5 이슈 (Phase 16 진입 전 권장 처리):
  - #43 chat.spec MSW 모킹
  - #44 home.spec 셀렉터 정확화
  - #45 join.spec 셀렉터 정확화
  - #46 auth.spec:22 backdrop
  - #47 auth.spec mobile navbar

## ADR-005 Transition milestones
- Wave 2 머지일: `2026-04-21` (BE + FE 동기화)
- Blocking 전환 기한: `2026-05-05` (Wave 2 + 14 days)

Co-authored-by: gs07103 <gwonseok02@gmail.com>