### PR TITLE
feat(17.6): DUAL_2PC trigger gap hotfix [FE]

### DIFF
--- a/src/03-pages/lab/lab/lab-page.test.tsx
+++ b/src/03-pages/lab/lab/lab-page.test.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import '@testing-library/jest-dom/vitest';
@@ -38,6 +38,19 @@ vi.mock('@/05-features/signals', () => ({
     stopMeasurement: vi.fn(),
   })),
   SignalMeasurer: () => null,
+}));
+
+/**
+ * dual-trigger API mock 수행함 — 네트워크 호출 방지함
+ */
+vi.mock('@/07-shared/api/dual-trigger', () => ({
+  postDualTrigger: vi.fn().mockResolvedValue({ status: 'triggered' }),
+  fetchRegistryStatus: vi.fn().mockResolvedValue({
+    ready: false,
+    registered: 0,
+    attempts: 0,
+    inFlight: false,
+  }),
 }));
 
 /**
@@ -83,6 +96,8 @@ describe('LabPage 실험 시작 버튼 조건 render 검증 수행함', () => {
     (useDualSession as ReturnType<typeof vi.fn>).mockReturnValue({
       state: 'ready',
       partnerConnected: true,
+      registryStatus: null,
+      showFallback: false,
       setDualSessionState: vi.fn(),
     });
 
@@ -139,6 +154,8 @@ describe('LabPage 실험 시작 버튼 조건 render 검증 수행함', () => {
     (useDualSession as ReturnType<typeof vi.fn>).mockReturnValue({
       state: 'waiting',
       partnerConnected: false,
+      registryStatus: null,
+      showFallback: false,
       setDualSessionState: vi.fn(),
     });
 
@@ -186,6 +203,8 @@ describe('LabPage 실험 시작 버튼 조건 render 검증 수행함', () => {
     (useDualSession as ReturnType<typeof vi.fn>).mockReturnValue({
       state: 'idle',
       partnerConnected: false,
+      registryStatus: null,
+      showFallback: false,
       setDualSessionState: vi.fn(),
     });
 
@@ -215,5 +234,132 @@ describe('LabPage 실험 시작 버튼 조건 render 검증 수행함', () => {
     expect(
       screen.getByRole('button', { name: /실험 시작/ })
     ).toBeInTheDocument();
+  });
+});
+
+/**
+ * Phase 17.6 fallback 버튼 테스트 수행함
+ *
+ * T-FE-3: showFallback=true 상태에서 "다시 연결 시도" 버튼 클릭 시 POST /engine/dual-trigger 호출 검증함
+ * T-FE-5: dual-trigger 503 응답 시 오류 메시지 "대기 상태가 아닙니다" 표시 검증함
+ *
+ * 전제: T7(lab-page.tsx fallback button + handleManualTrigger 구현) 완료 후 pass함
+ * useDualSession mock으로 showFallback=true 강제, 네트워크는 dual-trigger mock 격리함
+ */
+describe('LabPage Phase 17.6 fallback 버튼 render + 클릭 검증 수행함', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // 모바일 판정 방지를 위해 데스크톱 너비 설정함
+    Object.defineProperty(window, 'innerWidth', {
+      writable: true,
+      configurable: true,
+      value: 1280,
+    });
+
+    // usePairing: groupId 있는 상태 mock 설정함 (fallback 버튼 표시 전제)
+    (usePairing as ReturnType<typeof vi.fn>).mockReturnValue({
+      groupId: 'test-group-fallback',
+      pairingCode: null,
+      timeLeft: 300,
+      pairedSubjects: [],
+      isAllPaired: false,
+      sessions: [],
+      startPairing: vi.fn(),
+      resetStatus: vi.fn(),
+      requestPairing: vi.fn(),
+      status: 'IDLE',
+      role: null,
+      subjectIndex: null,
+      sessionId: null,
+    });
+  });
+
+  it('T-FE-3: showFallback=true 상태에서 fallback 버튼 클릭 시 POST /engine/dual-trigger 호출 처리됨', async () => {
+    const { postDualTrigger } = await import('@/07-shared/api/dual-trigger');
+    const triggerMock = vi.mocked(postDualTrigger);
+    // triggered 응답으로 성공 케이스 구성함
+    triggerMock.mockResolvedValue({ status: 'triggered' });
+
+    // useDualSession: showFallback=true 상태 강제 설정함
+    (useDualSession as ReturnType<typeof vi.fn>).mockReturnValue({
+      state: 'invited',
+      partnerConnected: false,
+      registryStatus: {
+        ready: false,
+        registered: 0,
+        attempts: 0,
+        inFlight: false,
+      },
+      showFallback: true,
+      setDualSessionState: vi.fn(),
+    });
+
+    const user = userEvent.setup();
+    renderLabPage();
+
+    // 설정 드롭다운에서 DUAL 2PC 모드 선택 수행함
+    const allButtons = screen.getAllByRole('button');
+    const settingsBtnByIcon = allButtons.find((btn) =>
+      btn.querySelector('svg.lucide-settings')
+    );
+    if (settingsBtnByIcon) {
+      await user.click(settingsBtnByIcon);
+    }
+    const dual2pcBtn = await screen.findByText(/DUAL 2PC 모드/i);
+    await user.click(dual2pcBtn);
+
+    // fallback 버튼 클릭 후 dual-trigger 호출 확인함
+    const fallbackBtn = screen.getByText(/다시 연결 시도/);
+    await user.click(fallbackBtn);
+
+    await waitFor(() => {
+      expect(triggerMock).toHaveBeenCalledWith('test-group-fallback');
+    });
+  });
+
+  it('T-FE-5: dual-trigger 503 응답 시 오류 메시지 "대기 상태가 아닙니다" 표시 처리됨', async () => {
+    const { postDualTrigger } = await import('@/07-shared/api/dual-trigger');
+    const triggerMock = vi.mocked(postDualTrigger);
+    // 503 에러 시나리오 구성 — Axios 에러 형태로 reject 처리함
+    triggerMock.mockRejectedValue({
+      response: { status: 503, data: { message: 'pending 미충족' } },
+    });
+
+    // useDualSession: showFallback=true 상태 강제 설정함
+    (useDualSession as ReturnType<typeof vi.fn>).mockReturnValue({
+      state: 'invited',
+      partnerConnected: false,
+      registryStatus: {
+        ready: false,
+        registered: 0,
+        attempts: 0,
+        inFlight: false,
+      },
+      showFallback: true,
+      setDualSessionState: vi.fn(),
+    });
+
+    const user = userEvent.setup();
+    renderLabPage();
+
+    // DUAL 2PC 모드 선택 수행함
+    const allButtons = screen.getAllByRole('button');
+    const settingsBtnByIcon = allButtons.find((btn) =>
+      btn.querySelector('svg.lucide-settings')
+    );
+    if (settingsBtnByIcon) {
+      await user.click(settingsBtnByIcon);
+    }
+    const dual2pcBtn = await screen.findByText(/DUAL 2PC 모드/i);
+    await user.click(dual2pcBtn);
+
+    // fallback 버튼 클릭 후 503 오류 메시지 표시 확인함
+    const fallbackBtn = screen.getByText(/다시 연결 시도/);
+    await user.click(fallbackBtn);
+
+    await waitFor(() => {
+      expect(screen.getByText(/대기 상태가 아닙니다/)).toBeInTheDocument();
+    });
   });
 });

--- a/src/03-pages/lab/lab/lab-page.tsx
+++ b/src/03-pages/lab/lab/lab-page.tsx
@@ -11,6 +11,7 @@ import { useSignal } from '@/05-features/signals';
 import { QRGenerator, usePairing } from '@/05-features/sessions';
 import { OperatorInviteQr } from '@/05-features/sessions/ui/operator-invite-qr.component';
 import { useDualSession } from '@/05-features/sessions/model/use-dual-session';
+import { postDualTrigger } from '@/07-shared/api/dual-trigger';
 import { DualSessionBanner } from '@/04-widgets/dual-session-banner';
 import { SignalComparisonWidget } from '@/04-widgets';
 import { EXPERIMENT_CONFIG } from '@/07-shared';
@@ -110,8 +111,46 @@ const LabPage = () => {
   const {
     state: dualState,
     partnerConnected,
+    registryStatus,
+    showFallback,
     setDualSessionState,
   } = useDualSession(groupId, mode);
+
+  // 수동 트리거 상태 정의함
+  const [manualTriggerError, setManualTriggerError] = useState<string | null>(
+    null
+  );
+  const [manualTriggerPending, setManualTriggerPending] = useState(false);
+
+  /**
+   * DE 엔진 연결 지연 시 수동 트리거 재시도 처리함
+   * race 방지: ready 상태이면 즉시 반환함
+   * 더블클릭 방지: pending 중이면 즉시 반환함
+   */
+  const handleManualTrigger = async () => {
+    if (!groupId) return;
+    if (registryStatus?.ready) return;
+    if (manualTriggerPending) return;
+
+    setManualTriggerPending(true);
+    setManualTriggerError(null);
+    try {
+      await postDualTrigger(groupId);
+    } catch (err) {
+      const status = (err as { response?: { status?: number } })?.response
+        ?.status;
+      if (status === 503) {
+        setManualTriggerError(
+          '두 데이터 엔진이 모두 대기 상태가 아닙니다.' +
+            ' EMOTIV App과 DE 기동 상태를 확인하세요.'
+        );
+      } else {
+        setManualTriggerError(`연결 시도 실패: ${(err as Error).message}`);
+      }
+    } finally {
+      setManualTriggerPending(false);
+    }
+  };
 
   const subject1Signal = useSignal(sessions[0]?.id ?? null, {
     experimentMode: mode,
@@ -249,8 +288,39 @@ const LabPage = () => {
       );
     }
 
-    // DUAL_2PC 모드: 파트너 PC 초대 QR 버튼 표시함 (PLAN L175)
+    // DUAL_2PC 모드: 폴백 노출 + 파트너 PC 초대 QR 버튼 표시함 (PLAN L175)
     if (mode === 'DUAL_2PC') {
+      // showFallback=true → QR 버튼 + 수동 재연결 버튼 병렬 노출함
+      if (showFallback) {
+        return (
+          <div className="flex flex-col gap-3 items-center">
+            <button
+              onClick={() => setIsDual2pcQrVisible((prev) => !prev)}
+              className="group relative inline-flex items-center cursor-pointer gap-2 px-6 py-3 bg-violet-600 hover:bg-violet-500 text-white rounded-2xl font-bold transition-all duration-300 hover:scale-105 shadow-lg shadow-violet-500/20"
+            >
+              {isDual2pcQrVisible ? <X size={20} /> : <QrCode size={20} />}
+              <span>{isDual2pcQrVisible ? '닫기' : '파트너 PC 초대 QR'}</span>
+            </button>
+            <button
+              onClick={() => void handleManualTrigger()}
+              disabled={manualTriggerPending || !!registryStatus?.ready}
+              className={`text-sm ${
+                manualTriggerError ? 'text-rose-500' : 'text-amber-500'
+              } underline disabled:opacity-50`}
+            >
+              {manualTriggerPending
+                ? '연결 시도 중...'
+                : '엔진 연결이 지연됩니다. 다시 연결 시도'}
+            </button>
+            {manualTriggerError ? (
+              <p className="text-xs text-rose-500 max-w-md">
+                {manualTriggerError}
+              </p>
+            ) : null}
+          </div>
+        );
+      }
+
       return (
         <button
           onClick={() => setIsDual2pcQrVisible((prev) => !prev)}

--- a/src/05-features/sessions/model/use-dual-session.test.ts
+++ b/src/05-features/sessions/model/use-dual-session.test.ts
@@ -39,6 +39,16 @@ vi.mock('@/07-shared/config/config', () => ({
   },
 }));
 
+// dual-trigger API 모킹 처리함 (폴링 격리 목적)
+vi.mock('@/07-shared/api/dual-trigger', () => ({
+  fetchRegistryStatus: vi.fn().mockResolvedValue({
+    ready: false,
+    registered: 0,
+    attempts: 0,
+    inFlight: false,
+  }),
+}));
+
 /**
  * 등록된 소켓 이벤트 핸들러를 이름으로 추출하는 헬퍼 정의함
  */
@@ -103,12 +113,13 @@ describe('useDualSession — DUAL_2PC 세션 상태 전이 테스트 수행함',
     expect(result.current.state).toBe('joining');
   });
 
-  it('dual-session-ready 수신 시 state=measuring, partnerConnected=true 전이 처리됨 (v3 N-5)', () => {
+  it('dual-session-ready 수신 시 state=measuring 전이 처리됨 (Phase 17.6: partnerConnected는 polling 담당)', () => {
     const { result } = renderHook(() =>
       useDualSession('group-abc', 'DUAL_2PC')
     );
 
     // v3 N-5: 202 Accepted 직후 측정 시작 금지 — dual-session-ready 수신 시에만 전이 허용
+    // Phase 17.6: partnerConnected 설정은 registry-status polling이 담당함
     // joining 상태에서 ready 이벤트 수신 시 measuring 전이 검증함
     act(() => {
       result.current.setDualSessionState('joining');
@@ -122,7 +133,9 @@ describe('useDualSession — DUAL_2PC 세션 상태 전이 테스트 수행함',
     });
 
     expect(result.current.state).toBe('measuring');
-    expect(result.current.partnerConnected).toBe(true);
+    // partnerConnected는 registry-status polling ready=true 수신 시 전환됨
+    // 소켓 이벤트만으로는 변경되지 않음 — polling mock이 ready=false 반환하므로 false 유지
+    expect(result.current.partnerConnected).toBe(false);
   });
 
   it('dual-session-ready 수신 시 다른 groupId이면 상태 미전이 처리됨', () => {

--- a/src/05-features/sessions/model/use-dual-session.test.ts
+++ b/src/05-features/sessions/model/use-dual-session.test.ts
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * FE-3: useDualSession 훅 상태 전이 단위 테스트 수행함
  *
  * v3 N-5 렌즈 반영 검증:
@@ -12,6 +12,11 @@
  *   joining → measuring (dual-session-ready 이벤트)
  *   measuring → aborted (dual-session-failed 이벤트)
  *   measuring → completed (measurement-complete 이벤트)
+ *
+ * Phase 17.6 추가 범위 (T-FE-1/2/4):
+ *   registry-status polling ready=false→true 전환 시 partnerConnected 갱신
+ *   polling stuck 10초 지속 시 showFallback=true 전환
+ *   DUAL_2PC 아닌 모드에서 polling 비활성 검증
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
@@ -48,6 +53,8 @@ vi.mock('@/07-shared/api/dual-trigger', () => ({
     inFlight: false,
   }),
 }));
+
+import { fetchRegistryStatus } from '@/07-shared/api/dual-trigger';
 
 /**
  * 등록된 소켓 이벤트 핸들러를 이름으로 추출하는 헬퍼 정의함
@@ -211,5 +218,109 @@ describe('useDualSession — DUAL_2PC 세션 상태 전이 테스트 수행함',
     expect(offEventNames).toContain('dual-session-ready');
     expect(offEventNames).toContain('dual-session-failed');
     expect(offEventNames).toContain('measurement-complete');
+  });
+});
+
+/**
+ * Phase 17.6 polling 테스트 수행함
+ *
+ * T-FE-1: registry-status ready=false→true 전환 시 partnerConnected 갱신 검증함
+ * T-FE-2: ready=false 10초 이상 지속 시 showFallback=true 전환 검증함
+ * T-FE-4: DUAL_2PC 아닌 모드에서 polling 비활성 검증함
+ */
+describe('useDualSession — Phase 17.6 polling 상태 전이 테스트 수행함', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('T-FE-1: polling ready false→true 전환 시 partnerConnected true 갱신 처리됨', async () => {
+    // 순서대로 다른 응답을 반환하는 mock 구성함
+    const fetchMock = vi.mocked(fetchRegistryStatus);
+    fetchMock
+      .mockResolvedValueOnce({
+        ready: false,
+        registered: 0,
+        attempts: 0,
+        inFlight: true,
+      })
+      .mockResolvedValueOnce({
+        ready: false,
+        registered: 1,
+        attempts: 1,
+        inFlight: true,
+      })
+      .mockResolvedValue({
+        ready: true,
+        registered: 2,
+        attempts: 1,
+        inFlight: false,
+      });
+
+    const { result } = renderHook(() => useDualSession('grp-1', 'DUAL_2PC'));
+
+    // 초기 상태 확인함
+    expect(result.current.partnerConnected).toBe(false);
+
+    // 1초 인터벌 3회 tick 처리함 — 3번째 tick에서 ready=true 수신 후 partnerConnected 갱신 유도함
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+
+    // ready=true 수신 후 partnerConnected true 전환 확인함
+    expect(result.current.partnerConnected).toBe(true);
+  });
+
+  it('T-FE-2: polling ready=false 10초 지속 시 showFallback true 전환 처리됨', async () => {
+    // 항상 stuck 상태(inFlight=false + ready=false) 반환하는 mock 구성함
+    vi.mocked(fetchRegistryStatus).mockResolvedValue({
+      ready: false,
+      registered: 0,
+      attempts: 0,
+      inFlight: false,
+    });
+
+    const { result } = renderHook(() => useDualSession('grp-1', 'DUAL_2PC'));
+
+    // 초기 showFallback false 확인함
+    expect(result.current.showFallback).toBe(false);
+
+    // 1초 인터벌 11회 tick 진행 처리함 — 10초 초과 후 showFallback 전환 유도함
+    for (let i = 0; i < 11; i++) {
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1000);
+      });
+    }
+
+    // 10초 이상 stuck 지속 시 showFallback true 전환 확인함
+    expect(result.current.showFallback).toBe(true);
+  });
+
+  it('T-FE-4: DUAL_2PC 모드 아니면 registry-status polling 비활성 처리됨', async () => {
+    const fetchMock = vi.mocked(fetchRegistryStatus);
+    // mock 초기화하여 호출 여부를 정확히 감지함
+    fetchMock.mockClear();
+
+    renderHook(() => useDualSession('grp-1', 'DUAL'));
+
+    // 3.5초 경과해도 폴링이 발생하지 않아야 함
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3500);
+    });
+
+    // DUAL 모드에서는 registry-status 호출 없음 확인함
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/src/05-features/sessions/model/use-dual-session.ts
+++ b/src/05-features/sessions/model/use-dual-session.ts
@@ -3,6 +3,10 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
 import { getSocket } from '@/07-shared/lib/socket-client';
 import { config } from '@/07-shared/config/config';
+import {
+  fetchRegistryStatus,
+  type RegistryStatus,
+} from '@/07-shared/api/dual-trigger';
 
 /**
  * DUAL_2PC 세션 상태 유니온 타입 정의함
@@ -49,7 +53,7 @@ interface MeasurementCompletePayload {
  *
  * @param groupId - 그룹 식별자 (null이면 미초기화 상태임)
  * @param experimentMode - 현재 실험 모드 (DUAL_2PC 여부 판별 목적)
- * @returns 세션 상태 + 파트너 연결 여부 + 상태 직접 변경 함수
+ * @returns 세션 상태 + 파트너 연결 여부 + 등록 상태 + 폴백 표시 여부 + 상태 직접 변경 함수
  */
 export function useDualSession(
   groupId: string | null,
@@ -57,10 +61,19 @@ export function useDualSession(
 ): {
   state: DualSessionState;
   partnerConnected: boolean;
+  registryStatus: RegistryStatus | null;
+  showFallback: boolean;
   setDualSessionState: (s: DualSessionState) => void;
 } {
   const [state, setState] = useState<DualSessionState>('invited');
   const [partnerConnected, setPartnerConnected] = useState(false);
+
+  // registry-status polling 상태 정의함
+  const [registryStatus, setRegistryStatus] = useState<RegistryStatus | null>(
+    null
+  );
+  const failedSinceRef = useRef<number | null>(null);
+  const [showFallback, setShowFallback] = useState(false);
 
   // 이벤트 핸들러 ref 보관하여 정확한 off 처리 가능하게 함
   const readyHandlerRef = useRef<
@@ -84,11 +97,11 @@ export function useDualSession(
 
     const socket = getSocket(config.api.socketUrl ?? config.api.baseUrl);
 
-    // dual-session-ready: BE가 두 DE 등록 완료 + stimulus 준비됨을 통보
+    // dual-session-ready: BE가 측정 전이 신호 emit 처리함
+    // partnerConnected 설정은 polling이 담당하므로 상태 전이만 수행함
     const readyHandler = ({ groupId: gid }: DualSessionReadyPayload) => {
       if (gid !== groupId) return; // 다른 그룹 이벤트 무시함
       setState('measuring');
-      setPartnerConnected(true);
     };
 
     // dual-session-failed: BE 측 60초 timeout 또는 처리 오류 발생함
@@ -129,5 +142,66 @@ export function useDualSession(
     };
   }, [groupId, experimentMode]);
 
-  return { state, partnerConnected, setDualSessionState };
+  /**
+   * registry-status 1초 폴링 수행함 (DUAL_2PC + groupId 존재 시만)
+   * ready=true 수신 → partnerConnected=true + state 'invited'→'ready' 전이
+   * 10초간 inFlight=false + ready=false 지속 → showFallback=true 처리함
+   */
+  useEffect(() => {
+    if (!groupId || experimentMode !== 'DUAL_2PC') return;
+
+    let cancelled = false;
+    let activeAbort: AbortController | null = null;
+
+    const intervalId = setInterval(async () => {
+      if (cancelled) return;
+      activeAbort?.abort();
+      activeAbort = new AbortController();
+
+      try {
+        const status = await fetchRegistryStatus(groupId, activeAbort.signal);
+        if (cancelled) return;
+        setRegistryStatus(status);
+
+        if (status.ready) {
+          // 등록 완료 → 파트너 연결 확정 + 상태 전이 수행함
+          setPartnerConnected(true);
+          setState((prev) => (prev === 'invited' ? 'ready' : prev));
+          failedSinceRef.current = null;
+          setShowFallback(false);
+        } else {
+          // 미완료 상태 → stuck 여부 판별 후 폴백 노출 결정함
+          const isStuck = !status.inFlight && !status.ready;
+          if (isStuck) {
+            if (failedSinceRef.current === null) {
+              failedSinceRef.current = Date.now();
+            } else if (Date.now() - failedSinceRef.current >= 10_000) {
+              setShowFallback(true);
+            }
+          } else {
+            failedSinceRef.current = null;
+            setShowFallback(false);
+          }
+        }
+      } catch (err) {
+        // AbortError는 정상 취소이므로 무시함
+        if ((err as Error).name === 'AbortError') return;
+        // 네트워크 오류 → 다음 tick 재시도 처리함
+      }
+    }, 1000);
+
+    return () => {
+      cancelled = true;
+      activeAbort?.abort();
+      clearInterval(intervalId);
+    };
+  }, [groupId, experimentMode]);
+
+  return {
+    state,
+    partnerConnected,
+    registryStatus,
+    showFallback,
+    setDualSessionState,
+  };
 }

--- a/src/07-shared/api/dual-trigger.ts
+++ b/src/07-shared/api/dual-trigger.ts
@@ -1,0 +1,80 @@
+import api from './base';
+
+// ──────────────────────────────────────────────
+// GET /engine/registry-status 응답 타입 정의함
+// ──────────────────────────────────────────────
+
+/**
+ * DE 그룹 등록 상태 응답 타입 정의함
+ *
+ * ready=true → 두 subject 모두 DE에 등록 완료 + 측정 가능 상태임
+ */
+export interface RegistryStatus {
+  ready: boolean;
+  registered: 0 | 1 | 2;
+  attempts: number;
+  inFlight: boolean;
+  lastError?:
+    | 'subject_1_failed'
+    | 'subject_2_failed'
+    | 'both_failed'
+    | 'invalid_secret'
+    | 'not_pending_mode'
+    | 'group_id_conflict'
+    | 'precondition_unmet';
+  startedAt?: number;
+  finishedAt?: number;
+}
+
+// ──────────────────────────────────────────────
+// POST /engine/dual-trigger 응답 타입 정의함
+// ──────────────────────────────────────────────
+
+/**
+ * dual-trigger 응답 상태 유니온 타입 정의함
+ */
+export type DualTriggerStatus = 'triggered' | 'in_progress' | 'already_ready';
+
+/**
+ * dual-trigger 응답 타입 정의함
+ */
+export interface DualTriggerResponse {
+  status: DualTriggerStatus;
+}
+
+// ──────────────────────────────────────────────
+// API 호출 함수 정의함
+// ──────────────────────────────────────────────
+
+/**
+ * DE 그룹 등록 상태 조회함 (DUAL_2PC polling 전용)
+ *
+ * @param groupId - 그룹 식별자
+ * @param signal - AbortController 신호 (폴링 취소 목적)
+ * @returns 등록 상태 객체
+ */
+export async function fetchRegistryStatus(
+  groupId: string,
+  signal?: AbortSignal
+): Promise<RegistryStatus> {
+  const { data } = await api.get<RegistryStatus>('/engine/registry-status', {
+    params: { groupId },
+    signal,
+  });
+  return data;
+}
+
+/**
+ * DE 양측 subject 등록 트리거 요청함 (DUAL_2PC 전용)
+ *
+ * @param groupId - 그룹 식별자
+ * @returns 트리거 응답 (triggered / in_progress / already_ready)
+ */
+export async function postDualTrigger(
+  groupId: string
+): Promise<DualTriggerResponse> {
+  const { data } = await api.post<DualTriggerResponse>('/engine/dual-trigger', {
+    groupId,
+  });
+  return data;
+}


### PR DESCRIPTION
## Summary

Phase 17.6 — DUAL_2PC trigger gap hotfix (FE 부분, 2 commits).

Phase 17 wiring 완료 후 실기기 Scenario 1 진입 직전 Codex 검증으로 발견된 **partnerConnected circular dependency** 해소:

- 기존: `dual-session-ready` 이벤트로만 partnerConnected=true → 이벤트는 실험 시작 후 emit → 실험 시작 버튼은 partnerConnected에 의존 → 무한 대기
- 해결: BE 신규 `GET /api/engine/registry-status` polling 1초 간격, ready=true 수신 시 partnerConnected=true. dual-session-ready는 measurement 전이만 담당.

## 2 atomic commits

- `8ab37fb` feat(sessions): T6 use-dual-session.ts polling 추가 + 신규 dual-trigger.ts (`fetchRegistryStatus` + `postDualTrigger`)
- `dd3476a` feat(lab): T7 lab-page fallback button + handleManualTrigger 503 UX + T8 5 신규 Vitest tests

## Test plan

- [x] `npm run format:check` PASS
- [x] `npm run typecheck` PASS
- [x] `npm run depcruise` PASS (174 modules / 385 deps / **0 violations**)
- [x] `npm run lint` PASS (0 warnings)
- [x] `npm run test` PASS — **272 tests / 27 files** (T-FE-1~5 5개 신규)
- [x] `npm run build` PASS (Compile 19.9s + 11 static pages)

## 5 신규 FE 테스트 (T-FE-1~5)

- T-FE-1: polling false → true 전환 시 partnerConnected 갱신
- T-FE-2: polling false 10초 지속 → showFallback=true
- T-FE-3: fallback 버튼 클릭 → POST /dual-trigger 호출
- T-FE-4: DUAL_2PC 모드 아니면 polling 비활성 (regression 방지)
- T-FE-5: 503 응답 시 manualTriggerError 메시지 표시

## 의존 PR

- BE PR: `feat(17.6): DUAL_2PC trigger gap hotfix [BE]` (먼저 머지 권장 — `/api/engine/registry-status` + `/api/engine/dual-trigger` 라우트 의존)
- DE PR: `feat(17.6): DUAL_2PC trigger gap hotfix [DE]` (pending registry 의존)

## 후속

- CodeRabbit 자동 리뷰 코멘트는 **별도 후속 PR**에서 처리 예정
- 머지 후 Phase 17 실기기 Scenario 1 재개

## 참조

- `.plans/17.6-dual-2pc-trigger-gap/PLAN.md` (rev.6)
- `.plans/17.6-dual-2pc-trigger-gap/CHECKLIST.md`
- `.plans/17.6-dual-2pc-trigger-gap/DONE.md`
