### PR TITLE
release: Phase K dev-mode admin force-pair (FE) → main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,10 @@ context/
 # Test artifacts
 playwright-report/
 test-results/
+
+# AI 에이전트 문서 (마인드 시그널 한정 — 본인만 사용, 팀 공유 안 함)
+# Why: 마인드 시그널은 이 패턴 적용을 본인 학습용으로 유지하고 다른 프로젝트에 templating할 예정.
+# 다른 모델 세션이 자동으로 추적 시도하지 않도록 .git/info/exclude 대신 .gitignore에 명시.
+AGENTS.md
+CLAUDE.md
+.agents/

--- a/e2e/admin-force-pair.spec.ts
+++ b/e2e/admin-force-pair.spec.ts
@@ -1,0 +1,211 @@
+/**
+ * Admin Force-Pair E2E — 5-tap dev mode + admin force-pair modal happy + 404 path
+ *
+ * - viewport: 데스크탑 1280x720 + UA 강제 (mobile project 실행 시에도 desktop 분기 유지)
+ * - JWT seed: localStorage.setItem('token', 'TEST-JWT') + Bearer header assert
+ * - mocks: POST /api/sessions + GET /api/sessions/group/:gid/status 폴링 + POST /api/sessions/:token/admin-pair
+ *
+ * @see .plans/K-dev-mode-force-pair/PLAN.md §8-2 (rev.4)
+ */
+
+import { test, expect, type Page, type Route } from '@playwright/test';
+
+const DESKTOP_VIEWPORT = { width: 1280, height: 720 };
+const DESKTOP_UA =
+  'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120 Safari/537.36';
+
+test.use({ viewport: DESKTOP_VIEWPORT, userAgent: DESKTOP_UA });
+
+/**
+ * JWT seed + 3 mock 라우트 등록 수행함.
+ *
+ * @param page - Playwright Page
+ * @param adminPairResponder - POST /api/sessions/:token/admin-pair 응답 핸들러
+ */
+async function seedAuthAndMocks(
+  page: Page,
+  adminPairResponder: (route: Route) => Promise<void> | void
+): Promise<void> {
+  await page.addInitScript(() => {
+    window.localStorage.setItem('token', 'TEST-JWT');
+  });
+
+  // ui-context의 getMe 호출 → BE 미가동 시 token 제거됨. 인증 통과 mock 처리함
+  await page.route('**/user/me', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        user: { name: '테스트 관리자', email: 'gwonseok02@gmail.com' },
+      }),
+    });
+  });
+
+  await page.route('**/api/sessions', async (route) => {
+    if (route.request().method() !== 'POST') {
+      await route.fallback();
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        status: 'success',
+        data: {
+          id: 'sess-1',
+          pairingToken: 'TEST-TOKEN-1',
+          groupId: 'gid-1',
+          subjectIndex: 1,
+        },
+      }),
+    });
+  });
+
+  await page.route('**/api/sessions/group/gid-1/status', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        status: 'success',
+        data: {
+          groupId: 'gid-1',
+          sessions: [
+            { subjectIndex: 1, status: 'CREATED', guestJoined: false },
+          ],
+        },
+      }),
+    });
+  });
+
+  await page.route(
+    '**/api/sessions/TEST-TOKEN-1/admin-pair',
+    adminPairResponder
+  );
+}
+
+/**
+ * Operator Dashboard 라벨 div 5회 탭으로 dev mode 진입함.
+ */
+async function fiveTapDevModeTrigger(page: Page): Promise<void> {
+  const target = page.locator('[data-testid="dev-mode-tap-target"]');
+  await target.waitFor({ state: 'visible' });
+  for (let i = 0; i < 5; i += 1) {
+    await target.click({ force: true });
+  }
+}
+
+test.describe('Admin Force-Pair — Happy Path (1280x720 desktop)', () => {
+  test('5-tap dev mode → email submit → 200 → modal close', async ({
+    page,
+  }) => {
+    const adminPairRequests: { authHeader?: string; body?: unknown }[] = [];
+
+    await seedAuthAndMocks(page, async (route) => {
+      const request = route.request();
+      const allHeaders = await request.allHeaders();
+      adminPairRequests.push({
+        authHeader: allHeaders['authorization'],
+        body: request.postDataJSON(),
+      });
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          status: 'success',
+          data: { id: 'sess-1' },
+        }),
+      });
+    });
+
+    const consoleErrors: string[] = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') consoleErrors.push(msg.text());
+    });
+
+    await page.goto('/lab');
+    await page.waitForLoadState('networkidle');
+
+    // Operator Dashboard 라벨 표시 확인 (데스크탑 분기 진입)
+    await expect(
+      page.locator('[data-testid="dev-mode-tap-target"]')
+    ).toBeVisible({ timeout: 15000 });
+
+    // Subject 01 QR 생성 → pairingCode = TEST-TOKEN-1 확정
+    await page
+      .getByRole('button', { name: /Subject 01 연결 QR 생성/ })
+      .click();
+
+    // 5-tap dev mode 진입
+    await fiveTapDevModeTrigger(page);
+
+    const dialog = page.getByRole('dialog', { name: 'Admin dev mode' });
+    await expect(dialog).toBeVisible();
+
+    await page.fill('input[name="email"]', 'gwonseok02@gmail.com');
+    await page.getByRole('button', { name: '강제 페어링' }).click();
+
+    await expect(dialog).toBeHidden();
+
+    expect(adminPairRequests).toHaveLength(1);
+    expect(adminPairRequests[0].authHeader).toBe('Bearer TEST-JWT');
+    expect(adminPairRequests[0].body).toEqual({
+      email: 'gwonseok02@gmail.com',
+    });
+
+    expect(consoleErrors).toEqual([]);
+  });
+});
+
+test.describe('Admin Force-Pair — Error Path 404 (1280x720 desktop)', () => {
+  test('404 응답 시 한국어 inline + modal 유지', async ({ page }) => {
+    await seedAuthAndMocks(page, async (route) => {
+      await route.fulfill({
+        status: 404,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          status: 'fail',
+          message: '대상 사용자를 찾을 수 없습니다.',
+        }),
+      });
+    });
+
+    const consoleErrors: string[] = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') consoleErrors.push(msg.text());
+    });
+
+    await page.goto('/lab');
+    await page.waitForLoadState('networkidle');
+    await expect(
+      page.locator('[data-testid="dev-mode-tap-target"]')
+    ).toBeVisible({ timeout: 15000 });
+
+    await page
+      .getByRole('button', { name: /Subject 01 연결 QR 생성/ })
+      .click();
+
+    await fiveTapDevModeTrigger(page);
+
+    const dialog = page.getByRole('dialog', { name: 'Admin dev mode' });
+    await expect(dialog).toBeVisible();
+
+    await page.fill('input[name="email"]', 'nonexistent@test.com');
+    await page.getByRole('button', { name: '강제 페어링' }).click();
+
+    // Next.js `__next-route-announcer__`도 role="alert" 보유 — 모달 alert만 필터링함
+    const alert = page
+      .getByRole('alert')
+      .filter({ hasText: '대상 사용자 또는 토큰' });
+    await expect(alert).toBeVisible();
+    await expect(dialog).toBeVisible();
+    expect(
+      await page.locator('input[name="email"]').inputValue()
+    ).toBe('nonexistent@test.com');
+
+    // 404 응답 fetch 자체에서 brower가 발생시키는 resource error는 의도된 mock 응답이므로 필터링함
+    const unexpectedErrors = consoleErrors.filter(
+      (msg) => !msg.includes('Failed to load resource')
+    );
+    expect(unexpectedErrors).toEqual([]);
+  });
+});

--- a/src/03-pages/lab/lab/lab-page.tsx
+++ b/src/03-pages/lab/lab/lab-page.tsx
@@ -18,6 +18,11 @@ import { EXPERIMENT_CONFIG } from '@/07-shared';
 import MobileLabView from './ui/mobile-lab-view';
 import SequentialFlow from './sequential-flow';
 import { useUI } from '@/app/providers/ui-context'; // 다크 라이트 모드를 위해 임포트 추가
+import {
+  useDevModeStore,
+  useTapCounter,
+  AdminForcePairModal,
+} from '@/05-features/dev-mode';
 
 // next.config.ts의 optimizePackageImports 설정으로 인해 성능 저하 없이 편리한 임포트 사용함
 import {
@@ -51,6 +56,13 @@ const LabPage = () => {
     () => true,
     () => false
   );
+
+  // dev mode 5-tap admin force-pair UI 진입 상태 구독함
+  const isDevModeOn = useDevModeStore((s) => s.isDevModeOn);
+  const setDevModeOn = useDevModeStore((s) => s.setOn);
+  const setDevModeOff = useDevModeStore((s) => s.setOff);
+  // windowMs 2000ms — CI Playwright 5-click 안정성 마진 확보함
+  const { increment: incrementTap } = useTapCounter(5, 2000, setDevModeOn);
 
   const [isMobile, setIsMobile] = useState(false);
   const [isQRVisible, setIsQRVisible] = useState(false);
@@ -373,7 +385,11 @@ const LabPage = () => {
           className={`flex flex-col md:flex-row md:items-end justify-between gap-6 border-b pb-10 ${isDark ? 'border-white/5' : 'border-slate-200'}`}
         >
           <div className="space-y-3">
-            <div className="flex items-center gap-2 text-indigo-500 mb-1">
+            <div
+              className="flex items-center gap-2 text-indigo-500 mb-1 cursor-default"
+              onClick={incrementTap}
+              data-testid="dev-mode-tap-target"
+            >
               <LayoutDashboard size={18} />
               <span className="text-[10px] font-black uppercase tracking-[0.2em]">
                 Operator Dashboard
@@ -666,6 +682,12 @@ const LabPage = () => {
           </div>
         </div>
       </div>
+      <AdminForcePairModal
+        isOpen={isDevModeOn}
+        onClose={setDevModeOff}
+        pairingToken={pairingCode}
+        theme={isDark ? 'dark' : 'light'}
+      />
     </main>
   );
 };

--- a/src/05-features/dev-mode/index.ts
+++ b/src/05-features/dev-mode/index.ts
@@ -1,0 +1,3 @@
+export { useDevModeStore } from './model/dev-mode.store';
+export { useTapCounter } from './model/use-tap-counter.hook';
+export { default as AdminForcePairModal } from './ui/admin-force-pair-modal.component';

--- a/src/05-features/dev-mode/model/dev-mode.store.ts
+++ b/src/05-features/dev-mode/model/dev-mode.store.ts
@@ -1,0 +1,27 @@
+'use client';
+
+import { create } from 'zustand';
+
+/**
+ * dev mode 단일 토글 store 정의함. session-only persist X.
+ * 새로고침 시 자동 reset 처리함 (Zustand 5.x 기본 동작).
+ *
+ * 'use client' 의무 — Next.js 16 App Router에서 Server Component import 시 런타임 오류 방지함.
+ */
+interface DevModeState {
+  isDevModeOn: boolean;
+  setOn: () => void;
+  setOff: () => void;
+}
+
+const INITIAL_STATE = { isDevModeOn: false } as const;
+
+export const useDevModeStore = create<DevModeState>((set) => ({
+  ...INITIAL_STATE,
+  setOn: () => set({ isDevModeOn: true }),
+  setOff: () => set({ isDevModeOn: false }),
+}));
+
+// test 환경 reset 패턴 — partial merge로 action 보존 처리함
+// useDevModeStore.setState({ isDevModeOn: false })
+// replace=true 사용 금지 — setOn/setOff action을 지워 FM-1 등에서 깨짐.

--- a/src/05-features/dev-mode/model/use-tap-counter.hook.test.ts
+++ b/src/05-features/dev-mode/model/use-tap-counter.hook.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useTapCounter } from './use-tap-counter.hook';
+import { useDevModeStore } from './dev-mode.store';
+
+describe('use-tap-counter + dev-mode.store — FM 시나리오', () => {
+  beforeEach(() => {
+    // 시작점 0 고정으로 재현성 보장함 (vi.useFakeTimers의 now option)
+    vi.useFakeTimers({ now: 0 });
+    // partial merge로 action 보존 — replace=true 사용 금지함
+    useDevModeStore.setState({ isDevModeOn: false });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // FM-1
+  it('2초 내 5-tap 도달 시 onReach 호출 + devMode ON 전이함', () => {
+    const onReach = vi.fn(() => useDevModeStore.getState().setOn());
+    const { result } = renderHook(() => useTapCounter(5, 2000, onReach));
+
+    act(() => {
+      for (let i = 0; i < 5; i += 1) {
+        result.current.increment();
+      }
+    });
+
+    expect(onReach).toHaveBeenCalledTimes(1);
+    expect(useDevModeStore.getState().isDevModeOn).toBe(true);
+  });
+
+  // FM-2
+  it('3-tap만 한 경우 onReach 미호출 + devMode OFF 유지함', () => {
+    const onReach = vi.fn();
+    const { result } = renderHook(() => useTapCounter(5, 2000, onReach));
+
+    act(() => {
+      for (let i = 0; i < 3; i += 1) {
+        result.current.increment();
+      }
+    });
+
+    expect(onReach).not.toHaveBeenCalled();
+    expect(useDevModeStore.getState().isDevModeOn).toBe(false);
+  });
+
+  // FM-3
+  it('첫 tap 후 2초 초과 시 counter reset — 5-tap 누적 불성공 확인함', () => {
+    const onReach = vi.fn();
+    const { result } = renderHook(() => useTapCounter(5, 2000, onReach));
+
+    // t=0: 첫 tap
+    act(() => {
+      result.current.increment();
+    });
+    // t=2100ms (window 초과)
+    vi.setSystemTime(new Date(2100));
+    // 추가 4-tap — 첫 tap reset 후 count=4 (5 미달)
+    act(() => {
+      for (let i = 0; i < 4; i += 1) {
+        result.current.increment();
+      }
+    });
+
+    expect(onReach).not.toHaveBeenCalled();
+  });
+
+  // FM-4 — stamps + windowMs 2000
+  it('tap 간격 1100ms × 5회 — 매 두 번째 tap마다 firstTap window(2000ms) 초과 발생 → 누적 5 도달 안 함', () => {
+    const onReach = vi.fn();
+    const { result } = renderHook(() => useTapCounter(5, 2000, onReach));
+
+    // stamps: [0, 1100, 2200, 3300, 4400] — 각 1100ms 간격
+    // t=0:    첫 tap, count=1, firstTap=0
+    // t=1100: 1100-0=1100 < 2000 → count=2 (window 내)
+    // t=2200: 2200-0=2200 > 2000 → reset, count=1, firstTap=2200
+    // t=3300: 3300-2200=1100 < 2000 → count=2 (window 내)
+    // t=4400: 4400-2200=2200 > 2000 → reset, count=1, firstTap=4400
+    // 결과: 어느 시점에도 count 5 미도달 → onReach 미호출
+    const stamps = [0, 1100, 2200, 3300, 4400];
+    for (const t of stamps) {
+      vi.setSystemTime(new Date(t));
+      act(() => {
+        result.current.increment();
+      });
+    }
+
+    expect(onReach).not.toHaveBeenCalled();
+  });
+});

--- a/src/05-features/dev-mode/model/use-tap-counter.hook.ts
+++ b/src/05-features/dev-mode/model/use-tap-counter.hook.ts
@@ -1,0 +1,40 @@
+'use client';
+
+import { useRef } from 'react';
+
+/**
+ * N-tap counter 훅 정의함.
+ * 첫 tap 시점부터 windowMs 이내에 target 회 누적 시 onReach 호출함.
+ * 첫 tap 후 windowMs 초과 시 counter 전체 reset 처리함.
+ *
+ * @param target - 도달 목표 tap 수
+ * @param windowMs - 전체 window 시간 (첫 tap 시점부터 측정)
+ * @param onReach - target 도달 시 1회 호출 콜백
+ * @returns increment 핸들러
+ */
+export const useTapCounter = (
+  target: number,
+  windowMs: number,
+  onReach: () => void
+) => {
+  const countRef = useRef(0);
+  const firstTapAtRef = useRef<number>(0);
+
+  function increment() {
+    const now = Date.now();
+    if (countRef.current === 0 || now - firstTapAtRef.current > windowMs) {
+      // 첫 tap 또는 window 초과 — counter/firstTap reset 처리함
+      countRef.current = 1;
+      firstTapAtRef.current = now;
+    } else {
+      countRef.current += 1;
+    }
+    if (countRef.current >= target) {
+      countRef.current = 0;
+      firstTapAtRef.current = 0;
+      onReach();
+    }
+  }
+
+  return { increment };
+};

--- a/src/05-features/dev-mode/ui/admin-force-pair-modal.component.tsx
+++ b/src/05-features/dev-mode/ui/admin-force-pair-modal.component.tsx
@@ -1,0 +1,209 @@
+'use client';
+
+import React, { useState, useEffect, useRef } from 'react';
+import axios, { AxiosError } from 'axios';
+import { sessionApi } from '@/07-shared/api';
+
+interface AdminForcePairModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  pairingToken: string | null;
+  theme: 'light' | 'dark';
+}
+
+const REQUEST_TIMEOUT_MS = 8000;
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const AdminForcePairModal: React.FC<AdminForcePairModalProps> = ({
+  isOpen,
+  onClose,
+  pairingToken,
+  theme,
+}) => {
+  const [email, setEmail] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [isVisible, setIsVisible] = useState(false);
+  // AbortController — modal close 시 in-flight forcePairing abort 처리함
+  const abortRef = useRef<AbortController | null>(null);
+
+  // close 시 abort + state 초기화 보장함 (race condition 차단)
+  useEffect(() => {
+    if (!isOpen) {
+      setIsVisible(false);
+      return;
+    }
+    const t = setTimeout(() => setIsVisible(true), 10);
+    return () => {
+      clearTimeout(t);
+      abortRef.current?.abort();
+      abortRef.current = null;
+      setEmail('');
+      setError('');
+      setIsLoading(false);
+      setIsVisible(false);
+    };
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!pairingToken) return;
+    // FE 정규화 — BE Zod `.trim()`과 UX 정합 보장함
+    const normalizedEmail = email.trim();
+    if (!EMAIL_REGEX.test(normalizedEmail)) {
+      setError('이메일 형식 확인 필요함.');
+      return;
+    }
+    // 신규 AbortController per submit — 직전 in-flight abort 후 새 컨트롤러 생성함
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    setIsLoading(true);
+    setError('');
+    try {
+      await sessionApi.forcePairing(pairingToken, normalizedEmail, {
+        signal: controller.signal,
+        timeout: REQUEST_TIMEOUT_MS,
+      });
+      onClose();
+    } catch (err: unknown) {
+      // abort 된 경우 stale response 무시 처리함
+      if (controller.signal.aborted) return;
+      if (axios.isCancel(err)) return;
+      if (!axios.isAxiosError(err)) {
+        setError('알 수 없는 오류 발생함.');
+        return;
+      }
+      const axiosError = err as AxiosError<{ message?: string }>;
+      if (axiosError.code === 'ECONNABORTED') {
+        setError('요청 시간 초과 — 다시 시도 필요함.');
+        return;
+      }
+      const status = axiosError.response?.status;
+      switch (status) {
+        case 401:
+          setError('재로그인 후 다시 시도 필요함.');
+          break;
+        case 403:
+          setError('관리자 권한이 필요함.');
+          break;
+        case 404:
+          setError('대상 사용자 또는 토큰 불일치 발생함.');
+          break;
+        case 400:
+          setError('이메일 형식 확인 필요함.');
+          break;
+        default:
+          // network down (response=undefined) + 5xx 모두 default 분기 처리함
+          setError('요청 처리 실패함. 다시 시도 필요함.');
+      }
+    } finally {
+      // abort 후 stale finally가 새 state 덮어쓰지 않도록 가드 처리함
+      if (!controller.signal.aborted) {
+        setIsLoading(false);
+      }
+    }
+  };
+
+  const inputStyle = `w-full p-3 rounded-xl border transition-all focus:outline-none focus:ring-2 focus:ring-rose-500 ${
+    theme === 'dark'
+      ? 'border-white/10 bg-white/5 text-white'
+      : 'border-slate-300 bg-white text-slate-900'
+  }`;
+
+  return (
+    <div
+      role="dialog"
+      aria-label="Admin dev mode"
+      className={`fixed inset-0 z-[100] flex items-center justify-center p-4 transition-opacity duration-150 ease-out ${
+        isVisible ? 'opacity-100' : 'opacity-0'
+      }`}
+      style={{ height: '100dvh' }}
+    >
+      <div
+        className="absolute inset-0 bg-slate-950/60 backdrop-blur-md"
+        onClick={onClose}
+      />
+      <div
+        className={`relative w-full max-w-md max-h-[calc(100dvh-32px)] overflow-y-auto rounded-3xl border shadow-2xl ${
+          theme === 'dark'
+            ? 'bg-slate-900 text-white border-white/10'
+            : 'bg-white text-slate-900 border-slate-200'
+        }`}
+      >
+        <div className="p-8 space-y-6">
+          <header className="space-y-3">
+            <span className="inline-block bg-rose-500/10 border border-rose-500/30 text-rose-400 rounded-full px-3 py-1 text-xs font-bold uppercase tracking-wider">
+              Admin dev mode
+            </span>
+            <h2 className="text-2xl font-black tracking-tight">강제 페어링</h2>
+            <p
+              className={theme === 'dark' ? 'text-slate-400' : 'text-slate-500'}
+            >
+              대상 사용자 이메일 입력으로 현재 세션에 강제 연결 수행함.
+            </p>
+          </header>
+
+          {error ? (
+            <div
+              role="alert"
+              className="p-3 rounded-lg bg-red-500/10 border border-red-500/20 text-red-500 text-sm"
+            >
+              {error}
+            </div>
+          ) : null}
+
+          {!pairingToken ? (
+            <div className="p-3 rounded-lg bg-amber-500/10 border border-amber-500/20 text-amber-500 text-sm">
+              세션 토큰을 찾을 수 없음. QR 생성 후 재시도 필요함.
+            </div>
+          ) : null}
+
+          <form onSubmit={handleSubmit} noValidate className="space-y-4">
+            {/* noValidate: HTML5 native validation 비활성, 수동 정규식 검증 일관성 보장함 */}
+            <input
+              type="email"
+              name="email"
+              inputMode="email"
+              autoComplete="email"
+              autoCapitalize="none"
+              spellCheck={false}
+              placeholder="user@example.com"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className={inputStyle}
+              disabled={isLoading}
+              aria-invalid={error ? 'true' : 'false'}
+            />
+            <div className="flex gap-3">
+              <button
+                type="button"
+                onClick={onClose}
+                disabled={isLoading}
+                className={`flex-1 py-3 rounded-xl font-bold transition-all disabled:opacity-50 cursor-pointer ${
+                  theme === 'dark'
+                    ? 'bg-white/5 hover:bg-white/10 text-white'
+                    : 'bg-slate-100 hover:bg-slate-200 text-slate-700'
+                }`}
+              >
+                닫기
+              </button>
+              <button
+                type="submit"
+                disabled={isLoading || !pairingToken}
+                className="flex-1 py-3 bg-rose-600 hover:bg-rose-700 text-white rounded-xl font-bold transition-all disabled:opacity-50 cursor-pointer"
+              >
+                {isLoading ? '처리 중...' : '강제 페어링'}
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AdminForcePairModal;

--- a/src/05-features/dev-mode/ui/admin-force-pair-modal.test.tsx
+++ b/src/05-features/dev-mode/ui/admin-force-pair-modal.test.tsx
@@ -1,0 +1,422 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom/vitest';
+import AdminForcePairModal from './admin-force-pair-modal.component';
+import { sessionApi } from '@/07-shared/api';
+
+vi.mock('@/07-shared/api', () => ({
+  sessionApi: { forcePairing: vi.fn() },
+}));
+
+describe('AdminForcePairModal — FAU 시나리오', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // FAU-1
+  it('valid email + valid token 입력 시 forcePairing 호출 후 close 처리함', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    (sessionApi.forcePairing as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: { status: 'success', data: { id: 'sess-1' } },
+    });
+
+    render(
+      <AdminForcePairModal
+        isOpen={true}
+        onClose={onClose}
+        pairingToken="TEST-TOKEN-1"
+        theme="dark"
+      />
+    );
+
+    await user.type(
+      screen.getByPlaceholderText('user@example.com'),
+      'gwonseok02@gmail.com'
+    );
+    await user.click(screen.getByRole('button', { name: '강제 페어링' }));
+
+    await waitFor(() => {
+      expect(sessionApi.forcePairing).toHaveBeenCalledWith(
+        'TEST-TOKEN-1',
+        'gwonseok02@gmail.com',
+        expect.objectContaining({
+          signal: expect.any(AbortSignal),
+          timeout: 8000,
+        })
+      );
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // FAU-2 — 수동 정규식 검증 (form noValidate)
+  it('invalid email 입력 시 수동 정규식 검증 fail + 한국어 inline + forcePairing 미호출 확인함', async () => {
+    const user = userEvent.setup();
+    render(
+      <AdminForcePairModal
+        isOpen={true}
+        onClose={vi.fn()}
+        pairingToken="TEST-TOKEN-1"
+        theme="dark"
+      />
+    );
+    await user.type(
+      screen.getByPlaceholderText('user@example.com'),
+      'not-an-email'
+    );
+    await user.click(screen.getByRole('button', { name: '강제 페어링' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('이메일 형식');
+    });
+    expect(sessionApi.forcePairing).not.toHaveBeenCalled();
+  });
+
+  // FAU-3
+  it('401 응답 시 재로그인 안내 inline message 노출함', async () => {
+    const user = userEvent.setup();
+    (sessionApi.forcePairing as ReturnType<typeof vi.fn>).mockRejectedValue({
+      isAxiosError: true,
+      response: { status: 401, data: {} },
+    });
+
+    render(
+      <AdminForcePairModal
+        isOpen={true}
+        onClose={vi.fn()}
+        pairingToken="TEST-TOKEN-1"
+        theme="dark"
+      />
+    );
+    await user.type(
+      screen.getByPlaceholderText('user@example.com'),
+      'test@test.com'
+    );
+    await user.click(screen.getByRole('button', { name: '강제 페어링' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('재로그인');
+    });
+  });
+
+  // FAU-4
+  it('403 응답 시 관리자 권한 필요 inline message 노출함', async () => {
+    const user = userEvent.setup();
+    (sessionApi.forcePairing as ReturnType<typeof vi.fn>).mockRejectedValue({
+      isAxiosError: true,
+      response: { status: 403, data: {} },
+    });
+
+    render(
+      <AdminForcePairModal
+        isOpen={true}
+        onClose={vi.fn()}
+        pairingToken="TEST-TOKEN-1"
+        theme="dark"
+      />
+    );
+    await user.type(
+      screen.getByPlaceholderText('user@example.com'),
+      'test@test.com'
+    );
+    await user.click(screen.getByRole('button', { name: '강제 페어링' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('관리자 권한');
+    });
+  });
+
+  // FAU-5
+  it('404 응답 시 대상 사용자 또는 토큰 불일치 message 노출함', async () => {
+    const user = userEvent.setup();
+    (sessionApi.forcePairing as ReturnType<typeof vi.fn>).mockRejectedValue({
+      isAxiosError: true,
+      response: { status: 404, data: {} },
+    });
+
+    render(
+      <AdminForcePairModal
+        isOpen={true}
+        onClose={vi.fn()}
+        pairingToken="TEST-TOKEN-1"
+        theme="dark"
+      />
+    );
+    await user.type(
+      screen.getByPlaceholderText('user@example.com'),
+      'test@test.com'
+    );
+    await user.click(screen.getByRole('button', { name: '강제 페어링' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        '대상 사용자 또는 토큰'
+      );
+    });
+  });
+
+  // FAU-6
+  it('pairingToken null 시 submit 버튼 disabled + 안내 노출함', () => {
+    render(
+      <AdminForcePairModal
+        isOpen={true}
+        onClose={vi.fn()}
+        pairingToken={null}
+        theme="dark"
+      />
+    );
+    expect(screen.getByRole('button', { name: '강제 페어링' })).toBeDisabled();
+    expect(
+      screen.getByText('세션 토큰을 찾을 수 없음. QR 생성 후 재시도 필요함.')
+    ).toBeInTheDocument();
+  });
+
+  // FAU-7 — 에러 후 close → 재open 시 state 초기화 검증함
+  it('에러 발생 후 close → 재open 시 email/error state 빈 상태로 초기화 확인함', async () => {
+    const user = userEvent.setup();
+    (sessionApi.forcePairing as ReturnType<typeof vi.fn>).mockRejectedValue({
+      isAxiosError: true,
+      response: { status: 404, data: {} },
+    });
+
+    const { rerender } = render(
+      <AdminForcePairModal
+        isOpen={true}
+        onClose={vi.fn()}
+        pairingToken="TEST-TOKEN-1"
+        theme="dark"
+      />
+    );
+    await user.type(
+      screen.getByPlaceholderText('user@example.com'),
+      'first@test.com'
+    );
+    await user.click(screen.getByRole('button', { name: '강제 페어링' }));
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+
+    // close (isOpen=false 전이)
+    rerender(
+      <AdminForcePairModal
+        isOpen={false}
+        onClose={vi.fn()}
+        pairingToken="TEST-TOKEN-1"
+        theme="dark"
+      />
+    );
+    // 재open
+    rerender(
+      <AdminForcePairModal
+        isOpen={true}
+        onClose={vi.fn()}
+        pairingToken="TEST-TOKEN-1"
+        theme="dark"
+      />
+    );
+
+    expect(
+      (screen.getByPlaceholderText('user@example.com') as HTMLInputElement)
+        .value
+    ).toBe('');
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  // FAU-8 — window descriptor try/finally restore
+  it('mobile-class viewport (375x667 시뮬레이션) 시 modal 100dvh + submit visible 확인함', () => {
+    const originalInnerWidth = window.innerWidth;
+    const originalInnerHeight = window.innerHeight;
+    Object.defineProperty(window, 'innerWidth', {
+      writable: true,
+      configurable: true,
+      value: 375,
+    });
+    Object.defineProperty(window, 'innerHeight', {
+      writable: true,
+      configurable: true,
+      value: 667,
+    });
+    try {
+      render(
+        <AdminForcePairModal
+          isOpen={true}
+          onClose={vi.fn()}
+          pairingToken="TEST-TOKEN-1"
+          theme="dark"
+        />
+      );
+      const dialog = screen.getByRole('dialog') as HTMLElement;
+      // vitest browser mode에서 toHaveStyle는 computed style을 검사하므로 inline style 직접 검증함
+      expect(dialog.style.height).toBe('100dvh');
+      expect(screen.getByRole('button', { name: '강제 페어링' })).toBeVisible();
+    } finally {
+      Object.defineProperty(window, 'innerWidth', {
+        writable: true,
+        configurable: true,
+        value: originalInnerWidth,
+      });
+      Object.defineProperty(window, 'innerHeight', {
+        writable: true,
+        configurable: true,
+        value: originalInnerHeight,
+      });
+    }
+  });
+
+  // FAU-9 — AbortController race
+  it('submit 후 modal close 시 stale response가 새 state 변경 안 함 (AbortController race)', async () => {
+    const user = userEvent.setup();
+    let signalRef: AbortSignal | undefined;
+    (sessionApi.forcePairing as ReturnType<typeof vi.fn>).mockImplementation(
+      (_token: string, _email: string, opts?: { signal?: AbortSignal }) => {
+        signalRef = opts?.signal;
+        return new Promise((_resolve, reject) => {
+          opts?.signal?.addEventListener('abort', () =>
+            reject(new DOMException('AbortError', 'AbortError'))
+          );
+        });
+      }
+    );
+
+    const { rerender } = render(
+      <AdminForcePairModal
+        isOpen={true}
+        onClose={vi.fn()}
+        pairingToken="TEST-TOKEN-1"
+        theme="dark"
+      />
+    );
+    await user.type(
+      screen.getByPlaceholderText('user@example.com'),
+      'test@test.com'
+    );
+    await user.click(screen.getByRole('button', { name: '강제 페어링' }));
+
+    // modal close → useEffect cleanup이 abort 호출
+    rerender(
+      <AdminForcePairModal
+        isOpen={false}
+        onClose={vi.fn()}
+        pairingToken="TEST-TOKEN-1"
+        theme="dark"
+      />
+    );
+    await waitFor(() => {
+      expect(signalRef?.aborted).toBe(true);
+    });
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  // FAU-10 — network error (response=undefined)
+  it('network error (response=undefined) 시 default "요청 처리 실패함" inline 노출함', async () => {
+    const user = userEvent.setup();
+    (sessionApi.forcePairing as ReturnType<typeof vi.fn>).mockRejectedValue({
+      isAxiosError: true,
+    });
+
+    render(
+      <AdminForcePairModal
+        isOpen={true}
+        onClose={vi.fn()}
+        pairingToken="TEST-TOKEN-1"
+        theme="dark"
+      />
+    );
+    await user.type(
+      screen.getByPlaceholderText('user@example.com'),
+      'test@test.com'
+    );
+    await user.click(screen.getByRole('button', { name: '강제 페어링' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('요청 처리 실패함');
+    });
+  });
+
+  // FAU-11 — ECONNABORTED (timeout)
+  it('ECONNABORTED 응답 시 "요청 시간 초과" inline 노출함', async () => {
+    const user = userEvent.setup();
+    (sessionApi.forcePairing as ReturnType<typeof vi.fn>).mockRejectedValue({
+      isAxiosError: true,
+      code: 'ECONNABORTED',
+      message: 'timeout of 8000ms exceeded',
+    });
+
+    render(
+      <AdminForcePairModal
+        isOpen={true}
+        onClose={vi.fn()}
+        pairingToken="TEST-TOKEN-1"
+        theme="dark"
+      />
+    );
+    await user.type(
+      screen.getByPlaceholderText('user@example.com'),
+      'test@test.com'
+    );
+    await user.click(screen.getByRole('button', { name: '강제 페어링' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('요청 시간 초과');
+    });
+  });
+
+  // FAU-12 — 비-axios 에러 (TypeError)
+  it('비-axios 에러 (TypeError) 발생 시 "알 수 없는 오류 발생함." inline 노출함', async () => {
+    const user = userEvent.setup();
+    (sessionApi.forcePairing as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new TypeError('Cannot read property of undefined')
+    );
+
+    render(
+      <AdminForcePairModal
+        isOpen={true}
+        onClose={vi.fn()}
+        pairingToken="TEST-TOKEN-1"
+        theme="dark"
+      />
+    );
+    await user.type(
+      screen.getByPlaceholderText('user@example.com'),
+      'test@test.com'
+    );
+    await user.click(screen.getByRole('button', { name: '강제 페어링' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('알 수 없는 오류');
+    });
+    expect(sessionApi.forcePairing).toHaveBeenCalled();
+  });
+
+  // FAU-13 — email trim
+  it('trailing space 포함 email 입력 시 trim 적용 + body 전송 확인함', async () => {
+    const user = userEvent.setup();
+    (sessionApi.forcePairing as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: { status: 'success', data: { id: 'sess-1' } },
+    });
+
+    render(
+      <AdminForcePairModal
+        isOpen={true}
+        onClose={vi.fn()}
+        pairingToken="TEST-TOKEN-1"
+        theme="dark"
+      />
+    );
+    await user.type(
+      screen.getByPlaceholderText('user@example.com'),
+      '  gwonseok02@gmail.com  '
+    );
+    await user.click(screen.getByRole('button', { name: '강제 페어링' }));
+
+    await waitFor(() => {
+      expect(sessionApi.forcePairing).toHaveBeenCalledWith(
+        'TEST-TOKEN-1',
+        'gwonseok02@gmail.com',
+        expect.objectContaining({
+          signal: expect.any(AbortSignal),
+          timeout: 8000,
+        })
+      );
+    });
+  });
+});

--- a/src/07-shared/api/session.ts
+++ b/src/07-shared/api/session.ts
@@ -59,6 +59,26 @@ const sessionApi = {
    */
   checkSessionStatus: (groupId: string) =>
     api.get<GroupStatusResponse>(`/sessions/group/${groupId}/status`),
+
+  /**
+   * Admin 강제 페어링 요청 수행함 — pairingToken 세션에 email 대상 사용자 강제 연결함.
+   *
+   * @param pairingToken - QR pairing 토큰 문자열
+   * @param email - 대상 사용자 이메일 (admin이 입력)
+   * @param options - axios per-request config (timeout / signal 등)
+   * @returns AxiosResponse 200 — body는 modal close trigger로만 사용함
+   * @throws AxiosError 401 — 인증 만료 / 403 — admin 권한 없음 / 404 — 대상 또는 토큰 불일치 / 400 — Zod validation / ECONNABORTED — timeout
+   */
+  forcePairing: (
+    pairingToken: string,
+    email: string,
+    options?: { signal?: AbortSignal; timeout?: number }
+  ) =>
+    api.post<PairingResponse>(
+      `/sessions/${pairingToken}/admin-pair`,
+      { email },
+      options
+    ),
 };
 
 export default sessionApi;


### PR DESCRIPTION
## 5/26 교수면담 시연 BLOCKING 해결 → production 배포

모바일 QR 카메라 페어링 실패 시 데스크탑 5-tap admin force-pair 우회 동선을
production canonical 도메인(`mind-signal-frontend.vercel.app`, `www.neurosignal.kr`,
`neurosignal.kr`)에서 사용 가능하도록 활성화한다.

PR #55 dev 머지(`e245296`, 2026-05-14) 이후 dev → main release가 누락되어
production deployment(`dpl_GttN... 7b2e8b1`, 2026-05-04 Phase 17.6)에 5-tap UI가
존재하지 않는 상태였음. 본 release로 해소.

### 포함 변경 (3 commits / 10 files / +1053 / -1)
- `e245296` Merge pull request #55 from KWONSEOK02/feat/dev-mode-force-pair
- `ed071c6` feat(sessions): add admin force-pair modal with 5-tap entry
- `adc4d17` chore: ignore AI agent docs (AGENTS.md / CLAUDE.md / .agents/)

### 의존성 (모두 MERGED)
- mind-signal-backend Phase J audit log `5bf6de5`/`fb4460b`
- mind-signal-backend Phase K admin-force-pair endpoint `8114101`/`10f84b3`
- Heroku Config Vars `ADMIN_EMAILS=gwonseok02@gmail.com` (release v62 반영 완료)

### 검증
PR #55 시점 6-step verify GREEN + Playwright E2E 2/2 PASS + Vitest 신규 17건 PASS.
main 머지 conflict 없음 (`git merge-tree` clean).

### Rollback
production rollback candidate: `dpl_GttNWx2ksspdiY8t8rNqAWq1zPm4` (5/4 17.6).
시연 후 회귀 발생 시 `vercel rollback dpl_GttN... --scope gwonseok02-gmailcoms-projects --yes`.

Co-authored-by: gs07103 &lt;gwonseok02@gmail.com&gt;


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 관리자 강제 페어링 기능 추가
  * 개발자 모드 활성화 메커니즘 추가

* **테스트**
  * 관리자 강제 페어링 플로우에 대한 e2e 및 단위 테스트 추가
  * 탭 카운터 메커니즘 테스트 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KWONSEOK02/mind-signal-frontend/pull/56)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->