### PR TITLE
fix(sessions): createdPairing body groupId null 전송 제거

### DIFF
--- a/src/05-features/sessions/model/pairing-engine.repro-dual-mode-qr.test.ts
+++ b/src/05-features/sessions/model/pairing-engine.repro-dual-mode-qr.test.ts
@@ -1,0 +1,284 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { PairingStep } from './pairing-engine';
+
+/**
+ * DUAL 모드 QR 미생성 버그 재현 — pairing-engine 통합 테스트 수행함
+ *
+ * root cause (engine 관점):
+ *   PairingStep.execute()가 sessionApi.createdPairing(groupId || undefined)를
+ *   호출하지만, session.ts 계층에서 `groupId || null`로 null 치환이 일어남.
+ *   BE가 400을 반환하면 execute() catch 블록이 onStatusUpdate('ERROR')를 호출하고
+ *   throw함. use-pairing.ts는 catch에서 setStatus(ERROR)로 전환함.
+ *   결과: pairingCode 미세팅, QR 미표시, 타이머 미시작.
+ */
+vi.mock('@/07-shared', () => ({
+  sessionApi: {
+    createdPairing: vi.fn(),
+    checkSessionStatus: vi.fn(),
+  },
+}));
+
+import { sessionApi } from '@/07-shared';
+const mockCreatedPairing = sessionApi.createdPairing as ReturnType<
+  typeof vi.fn
+>;
+const mockCheckStatus = sessionApi.checkSessionStatus as ReturnType<
+  typeof vi.fn
+>;
+
+// ────────────────────────────────────────────────────────────────────────────
+// 회귀 시뮬레이션 매핑
+//
+// Simulation A (현재 동작 — 버그 박제):
+//   BE 400 응답 → onStatusUpdate('ERROR') 호출 + execute() throw
+//   → pairingCode는 세팅되지 않음 (use-pairing에서 catch 블록 진입)
+//   → 타이머/폴링 미시작
+//   → 현재 코드 그대로라면 PASS (버그 존재 확인)
+//
+// Simulation B (fix 후 기대 동작 — fix 후 PASS):
+//   fix 후 BE 201 성공 → onStatusUpdate('ERROR') 미호출
+//   → pairingToken 정상 반환 → QR 표시 가능
+//
+// Simulation C (정상 흐름 — groupId 있는 경우):
+//   groupId='abc' 전달 시 BE 성공 → pairingToken 반환 → PASS
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('Reproduce: startPairing이 BE 400 응답 시 동작 박제함', () => {
+  let engine: PairingStep;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- vi.fn() 타입 호환용
+  let onStatusUpdate: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let onTimeUpdate: any;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    engine = new PairingStep('DUAL');
+    onStatusUpdate = vi.fn();
+    onTimeUpdate = vi.fn();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    engine.clear();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  /**
+   * Simulation A: BE 400 응답 → ERROR 콜백 + pairingCode null 유지 박제함
+   *
+   * groupId 없이 execute() 호출 시 session.ts 계층에서 null 전송 →
+   * BE 400 응답 → execute() catch 블록 → onStatusUpdate('ERROR') 호출 →
+   * throw 발생 확인함. 타이머와 폴링도 시작되지 않음을 검증함.
+   *
+   * 이 테스트는 현재 PASS (버그 재현 성공).
+   * fix 후에는 이 테스트가 FAIL로 전환되어 버그 재발 경보 역할을 수행함.
+   */
+  it('[Sim-A] BE 400 응답 시 onStatusUpdate("ERROR") 호출 + execute() throw 발생함 (버그 박제)', async () => {
+    // arrange: BE 400 응답 모킹 (null groupId 전송으로 인한 Validation 실패)
+    const be400Error = Object.assign(new Error('Bad Request'), {
+      response: {
+        status: 400,
+        data: { message: 'groupId must be a string' },
+      },
+    });
+    mockCreatedPairing.mockRejectedValue(be400Error);
+
+    // act + assert: execute()가 throw하는지 확인함
+    await expect(engine.execute(onStatusUpdate, onTimeUpdate)).rejects.toThrow(
+      'Bad Request'
+    );
+
+    // assert: ERROR 콜백 호출 확인
+    expect(onStatusUpdate).toHaveBeenCalledWith('ERROR');
+    expect(onStatusUpdate).toHaveBeenCalledTimes(1);
+
+    // assert: 타이머 시작 안 됨 — 400 에러 직후라 인터벌 설정 전 throw됨
+    onTimeUpdate.mockClear();
+    onStatusUpdate.mockClear();
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(onTimeUpdate).not.toHaveBeenCalled();
+    expect(onStatusUpdate).not.toHaveBeenCalled();
+  });
+
+  /**
+   * Simulation A-2: createdPairing에 undefined 전달 확인 박제함
+   *
+   * pairing-engine은 `groupId || undefined` 변환 후 createdPairing에 전달하지만
+   * session.ts에서 다시 `groupId || null`로 치환함. engine 레벨에서
+   * createdPairing 호출 시 인자가 undefined임을 직접 spy로 검증함.
+   * (null로 치환되는 지점은 session.ts 계층 — session.repro 테스트에서 박제)
+   */
+  it('[Sim-A2] groupId 없이 execute() 호출 시 createdPairing에 undefined 전달됨', async () => {
+    // arrange: 성공 응답 (engine 호출 인자 검증이 목적)
+    const mockPairingData = {
+      groupId: 'group-1',
+      subjectIndex: 0,
+      pairingToken: 'token-abc',
+      expiresAt: new Date(Date.now() + 300_000).toISOString(),
+    };
+    mockCreatedPairing.mockResolvedValue({
+      data: { status: 'success', data: mockPairingData },
+    } as never);
+    mockCheckStatus.mockResolvedValue({
+      data: {
+        data: {
+          groupId: 'group-1',
+          sessions: [
+            { subjectIndex: 0, status: 'waiting', guestJoined: false },
+          ],
+        },
+      },
+    } as never);
+
+    // act
+    await engine.execute(onStatusUpdate, onTimeUpdate);
+
+    // assert: engine이 createdPairing에 undefined를 전달함
+    // (session.ts 계층에서 undefined → null 치환이 일어나는 지점)
+    expect(mockCreatedPairing).toHaveBeenCalledWith(undefined);
+  });
+
+  /**
+   * Simulation B: fix 후 기대 동작 — BE 성공 시 ERROR 미호출 + 타이머 시작됨
+   *
+   * fix 후에는 null 대신 유효한 body가 전달되어 BE 201 성공 →
+   * onStatusUpdate('ERROR') 미호출 + 타이머 시작 + pairingToken 반환.
+   * 현재는 Sim-A 같은 null 전송 케이스가 이 경로로 와야 하지만
+   * null 전송으로 400이 나므로 이 케이스를 별도 시나리오로 확인함.
+   */
+  it('[Sim-B] groupId 있는 경우 BE 성공 시 ERROR 미호출 + 타이머 시작됨 (fix 후 Sim-A도 이 경로로 전환되어야 함)', async () => {
+    // arrange: groupId 있는 정상 케이스 — BE 201 성공
+    const mockPairingData = {
+      groupId: 'group-existing',
+      subjectIndex: 0,
+      pairingToken: 'token-success',
+      expiresAt: new Date(Date.now() + 300_000).toISOString(),
+    };
+    mockCreatedPairing.mockResolvedValue({
+      data: { status: 'success', data: mockPairingData },
+    } as never);
+    mockCheckStatus.mockResolvedValue({
+      data: {
+        data: {
+          groupId: 'group-existing',
+          sessions: [
+            { subjectIndex: 0, status: 'waiting', guestJoined: false },
+          ],
+        },
+      },
+    } as never);
+
+    // act
+    const result = await engine.execute(
+      onStatusUpdate,
+      onTimeUpdate,
+      'group-existing'
+    );
+
+    // assert: ERROR 콜백 미호출
+    expect(onStatusUpdate).not.toHaveBeenCalledWith('ERROR');
+
+    // assert: pairingToken 정상 반환됨
+    expect(result.pairingToken).toBe('token-success');
+
+    // assert: 타이머 시작됨
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(onTimeUpdate).toHaveBeenCalled();
+  });
+
+  /**
+   * Simulation C: groupId=null 직접 전달 시 engine 내부 null 처리 박제함
+   *
+   * use-pairing.ts의 startPairing은 `groupId` 상태를 engine에 전달함.
+   * 초기 상태는 null이므로 engine은 `null || undefined` = undefined를
+   * createdPairing에 전달함. session.ts에서 undefined → null 치환이 발생함.
+   */
+  it('[Sim-C] groupId=null 전달 시 createdPairing에 undefined가 전달됨', async () => {
+    // arrange
+    const mockPairingData = {
+      groupId: 'group-new',
+      subjectIndex: 0,
+      pairingToken: 'token-new',
+      expiresAt: new Date(Date.now() + 300_000).toISOString(),
+    };
+    mockCreatedPairing.mockResolvedValue({
+      data: { status: 'success', data: mockPairingData },
+    } as never);
+    mockCheckStatus.mockResolvedValue({
+      data: {
+        data: {
+          groupId: 'group-new',
+          sessions: [
+            { subjectIndex: 0, status: 'waiting', guestJoined: false },
+          ],
+        },
+      },
+    } as never);
+
+    // act: use-pairing의 초기 groupId(null)를 engine에 전달하는 것과 동일한 흐름
+    await engine.execute(onStatusUpdate, onTimeUpdate, null);
+
+    // assert: `null || undefined` = undefined → createdPairing(undefined) 호출됨
+    // session.ts에서 undefined → null 치환 발생 지점은 session.repro 테스트에서 박제
+    expect(mockCreatedPairing).toHaveBeenCalledWith(undefined);
+  });
+});
+
+/**
+ * DUAL 모드 QR 버그 — 전체 시나리오 연쇄 흐름 박제함
+ *
+ * use-pairing.startPairing() → engine.execute() → createdPairing(undefined)
+ * → session.ts: undefined → null → BE 400 → ERROR 콜백 → pairingCode 미세팅
+ * 각 단계 연결고리를 명시적으로 문서화함.
+ */
+describe('DUAL 모드 QR 버그 — 400 응답 후 폴링/타이머 미시작 박제함', () => {
+  let engine: PairingStep;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let onStatusUpdate: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let onTimeUpdate: any;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    engine = new PairingStep('DUAL');
+    onStatusUpdate = vi.fn();
+    onTimeUpdate = vi.fn();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    engine.clear();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  /**
+   * BE 400 응답 후 3초 경과해도 폴링/타이머 콜백이 발생하지 않음을 검증함.
+   * QR 미표시는 pairingCode가 null로 남아있기 때문임.
+   */
+  it('BE 400 응답 후 3초 진행해도 폴링/타이머 콜백 미발생함 (QR 미표시 원인 박제)', async () => {
+    // arrange: 400 응답
+    const be400Error = Object.assign(new Error('Bad Request'), {
+      response: { status: 400, data: { message: 'groupId null rejected' } },
+    });
+    mockCreatedPairing.mockRejectedValue(be400Error);
+
+    // act
+    await expect(
+      engine.execute(onStatusUpdate, onTimeUpdate)
+    ).rejects.toThrow();
+
+    // 에러 콜백 이후 초기화 확인
+    onStatusUpdate.mockClear();
+    onTimeUpdate.mockClear();
+
+    // 3초 경과
+    await vi.advanceTimersByTimeAsync(3000);
+
+    // assert: 타이머도 폴링도 시작 안 됨 → pairingCode 세팅 불가 → QR 없음
+    expect(onTimeUpdate).not.toHaveBeenCalled();
+    expect(onStatusUpdate).not.toHaveBeenCalled();
+    expect(mockCheckStatus).not.toHaveBeenCalled();
+  });
+});

--- a/src/07-shared/api/session.repro-dual-mode-qr.test.ts
+++ b/src/07-shared/api/session.repro-dual-mode-qr.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import sessionApi from './session';
+
+/**
+ * DUAL 모드 QR 미생성 버그 재현 테스트 수행함
+ *
+ * root cause: createdPairing(groupId?: string) 내부에서
+ *   `api.post('/sessions', { groupId: groupId || null })`
+ * groupId 인자 없이 호출하면 `groupId: null`을 BE에 전송함.
+ * BE는 null을 허용하지 않아 400 반환 → pairingCode 미세팅 → QR 미표시.
+ */
+vi.mock('./base', () => ({
+  api: {
+    post: vi.fn(),
+    get: vi.fn(),
+  },
+}));
+
+import { api } from './base';
+const mockPost = api.post as ReturnType<typeof vi.fn>;
+
+// ────────────────────────────────────────────────────────────────────────────
+// 회귀 시뮬레이션 매핑
+//
+// Simulation A (현재 동작 — 버그 박제):
+//   groupId 없이 createdPairing() 호출 → body = { groupId: null }
+//   → 현재 코드 그대로라면 PASS (버그 존재 확인)
+//
+// Simulation B (fix 후 기대 동작 — 현재 FAIL):
+//   fix 후에는 body에 groupId 키 자체 없거나 undefined여야 함
+//   → 현재 코드에서는 FAIL (null이므로)
+//
+// Simulation C (정상 케이스 — groupId 있을 때 전달):
+//   groupId='abc' 전달 시 body = { groupId: 'abc' } → PASS (의도 동작 확인)
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('Reproduce: createdPairing이 BE에 null 전송하는 버그 박제함', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  /**
+   * Simulation A: 옵션 D 적용 후 동작 박제 — groupId 인자 없으면 키 자체 생략함
+   *
+   * 조건부 spread (`groupId ? { groupId } : {}`) 결과 body에 groupId 키 자체
+   * 없음. fix 무력화 시 (예: `{ groupId: groupId || null }` 회귀) 이 테스트가
+   * FAIL로 전환되어 회귀 경보 역할 수행함.
+   */
+  it('[Sim-A] groupId 인자 없이 호출 시 body에 groupId 키 자체 없음 (옵션 D 박제)', async () => {
+    // arrange
+    mockPost.mockResolvedValue({
+      data: {
+        status: 'success',
+        data: {
+          groupId: '65c9f0b2a1b2c3d4e5f67899',
+          subjectIndex: 0,
+          pairingToken: 'token-abc',
+          expiresAt: '2026-06-01T12:00:00Z',
+        },
+      },
+    });
+
+    // act
+    await sessionApi.createdPairing();
+
+    // assert: 빈 객체 전송 박제 — groupId 키 자체 없음
+    expect(mockPost).toHaveBeenCalledWith('/sessions', {});
+
+    // 명시적 spy received body 인용
+    const receivedBody = mockPost.mock.calls[0][1] as Record<string, unknown>;
+    expect(receivedBody).not.toHaveProperty('groupId');
+  });
+
+  /**
+   * Simulation B: fix 후 기대 동작 박제 — 현재 FAIL
+   *
+   * fix 후에는 groupId 인자가 없을 때 body에 groupId 키가 없어야 하거나
+   * undefined여야 함. 현재 코드(groupId || null)는 null을 박으므로 이 테스트는
+   * 현재 FAIL임. fix 적용 시 PASS로 전환됨.
+   */
+  it('[Sim-B] 회귀 시뮬레이션 B — fix 후에는 body에 groupId 키가 없어야 함 (현재 FAIL)', async () => {
+    // arrange
+    mockPost.mockResolvedValue({
+      data: {
+        status: 'success',
+        data: {
+          groupId: 'group-123',
+          subjectIndex: 0,
+          pairingToken: 'token-abc',
+          expiresAt: '2026-06-01T12:00:00Z',
+        },
+      },
+    });
+
+    // act
+    await sessionApi.createdPairing();
+
+    // assert: fix 후 기대 — groupId 키 자체 없음 또는 undefined
+    // 현재는 null이 들어오므로 FAIL
+    const receivedBody = mockPost.mock.calls[0][1] as Record<string, unknown>;
+    expect(receivedBody).not.toHaveProperty('groupId');
+  });
+
+  /**
+   * Simulation C: groupId 정상 전달 케이스 — 현재 PASS (의도 동작 확인)
+   *
+   * 유효한 groupId 문자열을 전달하면 body에 올바르게 포함됨을 검증함.
+   * 이 테스트는 fix 전후 모두 PASS여야 함.
+   */
+  it('[Sim-C] groupId 전달 시 body에 해당 값이 정상 포함 처리됨', async () => {
+    // arrange
+    mockPost.mockResolvedValue({
+      data: {
+        status: 'success',
+        data: {
+          groupId: 'existing-group',
+          subjectIndex: 0,
+          pairingToken: 'token-xyz',
+          expiresAt: '2026-06-01T12:00:00Z',
+        },
+      },
+    });
+
+    // act
+    await sessionApi.createdPairing('existing-group');
+
+    // assert: groupId 값이 body에 정상 전달됨
+    expect(mockPost).toHaveBeenCalledWith('/sessions', {
+      groupId: 'existing-group',
+    });
+
+    const receivedBody = mockPost.mock.calls[0][1] as { groupId: unknown };
+    expect(receivedBody.groupId).toBe('existing-group');
+  });
+
+  /**
+   * Simulation A-2: 빈 문자열 인자도 키 생략 처리됨 (옵션 D D-5 시나리오)
+   *
+   * 조건부 spread는 falsy(null/undefined/'') 모두 키 제거함. fix 무력화 시
+   * 빈 문자열이 null로 전송되는 회귀가 재발하면 이 테스트가 경보 역할 수행함.
+   */
+  it('[Sim-A2] 빈 문자열 groupId 전달 시에도 body에 groupId 키 자체 없음 (옵션 D 박제)', async () => {
+    // arrange
+    mockPost.mockResolvedValue({
+      data: {
+        status: 'success',
+        data: {
+          groupId: '65c9f0b2a1b2c3d4e5f6788a',
+          subjectIndex: 0,
+          pairingToken: 'token-def',
+          expiresAt: '2026-06-01T12:00:00Z',
+        },
+      },
+    });
+
+    // act: 빈 문자열 전달 — falsy
+    await sessionApi.createdPairing('');
+
+    // assert: 빈 객체로 전송 — 키 자체 없음
+    const receivedBody = mockPost.mock.calls[0][1] as Record<string, unknown>;
+    expect(receivedBody).not.toHaveProperty('groupId');
+  });
+});

--- a/src/07-shared/api/session.test.ts
+++ b/src/07-shared/api/session.test.ts
@@ -37,14 +37,12 @@ describe('sessionApi — 세션 API 통합 테스트 수행함', () => {
       },
     };
 
-    it('groupId 없이 호출 시 POST /sessions에 null groupId 전송 처리함', async () => {
+    it('groupId 없이 호출 시 POST /sessions에 빈 객체 전송 처리함 (옵션 D)', async () => {
       mockPost.mockResolvedValue(mockResponse);
 
       const result = await sessionApi.createdPairing();
 
-      expect(mockPost).toHaveBeenCalledWith('/sessions', {
-        groupId: null,
-      });
+      expect(mockPost).toHaveBeenCalledWith('/sessions', {});
       expect(result.data.data.groupId).toBe('group-123');
     });
 

--- a/src/07-shared/api/session.ts
+++ b/src/07-shared/api/session.ts
@@ -46,7 +46,7 @@ const sessionApi = {
    * 운영자용 새로운 그룹 실험 세션 생성 요청 수행함
    */
   createdPairing: (groupId?: string) =>
-    api.post<PairingResponse>('/sessions', { groupId: groupId || null }),
+    api.post<PairingResponse>('/sessions', groupId ? { groupId } : {}),
 
   /**
    * 피실험자용 토큰 기반 그룹 합류 요청 수행함


### PR DESCRIPTION
## 변경 요약

`session.ts:48-49`의 `{ groupId: groupId || null }` 패턴을 조건부 spread (`groupId ? { groupId } : {}`)로 변경. groupId 인자가 falsy면 키 자체 생략하여 BE가 `default({})` 경로로 신규 그룹 생성하도록 함.

## 회귀 박제

- `session.repro-dual-mode-qr.test.ts` 단위 — Sim-A/A-2/B/C 4 PASS (fix 후 동작 박제 + 회귀 경보)
- `pairing-engine.repro-dual-mode-qr.test.ts` 통합 — Sim-A/A-2/B/C 5 PASS (BE 400 응답 시 ERROR 흐름 + 정상 시 타이머 시작 박제)
- `session.test.ts` 기존 unit test의 null 전송 박제도 빈 객체로 갱신

## 페어 PR

이 PR은 BE 측 짝 PR과 함께 적용되어야 함:
- BE: https://github.com/KWONSEOK02/mind-signal-backend/pull/64 (신규 groupId 24자리 ObjectId hex 통일)

배포 순서: **BE 먼저 머지 후 FE 머지**. FE 먼저 머지하면 첫 Subject 페어링은 복구되지만 BE가 8자리 groupId를 반환하여 두 번째 Subject 재페어링이 BE schema regex 거부로 400 회귀.

## 검증

- npm run verify 6 단계 GREEN (298/298 PASS, build success)
- DUAL 모드: 빈 body → BE 201 + 24자리 groupId 반환 → QR 정상 표시 가능
- DUAL_2PC 모드 영향: `operator-invite-qr.component`는 prop groupId만 사용, fix 영향 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * DUAL 모드 QR 페어링 오류 발생 시 폴링/타이머 미시작 문제를 해결했습니다.
  * 선택적 식별자 처리 시 불필요한 null 값 전송 문제를 개선했습니다.

* **테스트**
  * QR 페어링 오류 처리 및 재시도 메커니즘 관련 회귀 테스트를 추가했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KWONSEOK02/mind-signal-frontend/pull/57?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->