### PR TITLE
feat: DUAL_2PC 단일 헤드셋 subject_2 라이브 차트 렌더

### DIFF
--- a/src/03-pages/lab/lab/lab-page.test.tsx
+++ b/src/03-pages/lab/lab/lab-page.test.tsx
@@ -34,10 +34,24 @@ vi.mock('@/05-features/signals', () => ({
     isMeasuring: false,
     elapsedSeconds: 0,
     currentMetrics: null,
+    currentMetrics2: null,
     startMeasurement: vi.fn(),
     stopMeasurement: vi.fn(),
+    joinDualRoom: vi.fn(),
   })),
   SignalMeasurer: () => null,
+}));
+
+/**
+ * next/navigation mock 수행함 — useSearchParams의 groupId를 테스트에서 제어함 (F2).
+ * vi.hoisted로 mock 함수를 끌어올려 factory 내부 참조 안전성 보장함.
+ */
+const { mockSearchParamsGet } = vi.hoisted(() => ({
+  mockSearchParamsGet: vi.fn((_key: string): string | null => null),
+}));
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), refresh: vi.fn() }),
+  useSearchParams: () => ({ get: mockSearchParamsGet }),
 }));
 
 /**
@@ -162,7 +176,7 @@ describe('LabPage 실험 시작 버튼 조건 render 검증 수행함', () => {
     ).toBeInTheDocument();
   });
 
-  it('DUAL_2PC 모드 + groupId 있음 + partnerConnected=false → 파트너 PC 초대 QR 버튼 표시 처리됨', async () => {
+  it('DUAL_2PC 모드 + 페어링 완료 + partnerConnected=false → operator 합류(이 PC) 버튼 표시 처리됨', async () => {
     // useDualSession: 파트너 미연결 상태 mock 설정함
     (useDualSession as ReturnType<typeof vi.fn>).mockReturnValue({
       state: 'waiting',
@@ -172,8 +186,8 @@ describe('LabPage 실험 시작 버튼 조건 render 검증 수행함', () => {
       setDualSessionState: vi.fn(),
     });
 
-    // usePairing: groupId 있음 + 페어링 완료 상태 mock 설정함
-    // groupId 존재 시 표준 페어링 분기 통과하여 파트너 초대 QR 표시함
+    // usePairing: 페어링 완료(양쪽 PAIRED) 상태 mock 설정함
+    // pairedSubjects 충족 시 operator 합류(이 PC) 원클릭 버튼 표시함 (QR 제거됨)
     (usePairing as ReturnType<typeof vi.fn>).mockReturnValue({
       groupId: 'group-paired',
       pairingCode: null,
@@ -208,10 +222,8 @@ describe('LabPage 실험 시작 버튼 조건 render 검증 수행함', () => {
     const dual2pcBtn = await screen.findByText(/DUAL 2PC 모드/i);
     await user.click(dual2pcBtn);
 
-    // groupId 있고 partnerConnected=false이므로 파트너 PC 초대 QR 버튼 표시 확인함
-    expect(
-      screen.getByRole('button', { name: /파트너 PC 초대/ })
-    ).toBeInTheDocument();
+    // 페어링 완료 + partnerConnected=false이므로 operator 합류(이 PC) 버튼 표시 확인함
+    expect(screen.getByTestId('operator-self-join')).toBeInTheDocument();
   });
 
   it('DUAL_2PC 모드 + groupId 없음 + 페어링 미완료 → Subject 연결 QR 생성 버튼 표시 처리됨', async () => {
@@ -644,5 +656,145 @@ describe('LabPage DUAL_2PC inFlight 인디케이터 render 검증 수행함', ()
     await user.click(dual2pcBtn);
 
     expect(screen.queryByText(/등록 시도 중/)).not.toBeInTheDocument();
+  });
+});
+
+/**
+ * F2 — groupId provenance (신선한 pairing 우선, stale URL 표류 차단)
+ *
+ * 차트 0건 표류 근본원인 중 하나: 이전 operator-join 리다이렉트가 남긴
+ * stale ?groupId= 가 새 페어링 그룹을 덮어써 BE/FE 그룹ID가 어긋남.
+ * fix 전 RED(stale URL로 startDualByGroup 호출), fix 후 GREEN(pairing 우선).
+ */
+describe('LabPage F2 — groupId provenance (신선한 pairing 우선)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(window, 'innerWidth', {
+      writable: true,
+      configurable: true,
+      value: 1280,
+    });
+    mockSearchParamsGet.mockReturnValue(null);
+    (useDualSession as ReturnType<typeof vi.fn>).mockReturnValue({
+      state: 'ready',
+      partnerConnected: true,
+      registryStatus: null,
+      showFallback: false,
+      setDualSessionState: vi.fn(),
+    });
+    (usePairing as ReturnType<typeof vi.fn>).mockReturnValue({
+      groupId: 'fresh-pairing-group',
+      pairingCode: null,
+      timeLeft: 300,
+      pairedSubjects: [1, 2],
+      isAllPaired: true,
+      sessions: [
+        { id: 'session-1', subjectIndex: 1 },
+        { id: 'session-2', subjectIndex: 2 },
+      ],
+      startPairing: vi.fn(),
+      resetStatus: vi.fn(),
+      requestPairing: vi.fn(),
+      status: 'PAIRED',
+      subjectIndex: null,
+      sessionId: null,
+    });
+  });
+
+  it('stale URL ?groupId= 가 있어도 신선한 pairing groupId로 측정 시작함', async () => {
+    // URL에 옛 그룹이 남아 있는 상황 재현함
+    mockSearchParamsGet.mockReturnValue('stale-url-group');
+
+    const measurementApi = await import('@/07-shared/api/signal');
+    const startDualByGroupMock = vi.mocked(
+      measurementApi.default.startDualByGroup
+    );
+
+    const user = userEvent.setup();
+    renderLabPage();
+
+    const settingsBtn = screen
+      .getAllByRole('button')
+      .find((b) => b.querySelector('svg.lucide-settings'));
+    if (settingsBtn) await user.click(settingsBtn);
+    const dual2pcBtn = await screen.findByText(/DUAL 2PC 모드/i);
+    await user.click(dual2pcBtn);
+
+    const startBtn = screen.getByRole('button', { name: /실험 시작/ });
+    await user.click(startBtn);
+
+    // 신선한 pairing 그룹으로 호출되어야 함 (stale URL 무시)
+    expect(startDualByGroupMock).toHaveBeenCalledWith('fresh-pairing-group');
+    expect(startDualByGroupMock).not.toHaveBeenCalledWith('stale-url-group');
+  });
+});
+
+/**
+ * F3 — 실험 시작 중복 클릭 가드
+ *
+ * 더블클릭 시 두 번째 start가 BE 전이 가드로 400을 받아 dev 오버레이를 유발하던 버그.
+ * fix 전 RED(startDualByGroup 2회 호출), fix 후 GREEN(1회만).
+ */
+describe('LabPage F3 — 실험 시작 중복 클릭 가드', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(window, 'innerWidth', {
+      writable: true,
+      configurable: true,
+      value: 1280,
+    });
+    mockSearchParamsGet.mockReturnValue(null);
+    (useDualSession as ReturnType<typeof vi.fn>).mockReturnValue({
+      state: 'ready',
+      partnerConnected: true,
+      registryStatus: null,
+      showFallback: false,
+      setDualSessionState: vi.fn(),
+    });
+    (usePairing as ReturnType<typeof vi.fn>).mockReturnValue({
+      groupId: 'group-guard',
+      pairingCode: null,
+      timeLeft: 300,
+      pairedSubjects: [1, 2],
+      isAllPaired: true,
+      sessions: [
+        { id: 'session-1', subjectIndex: 1 },
+        { id: 'session-2', subjectIndex: 2 },
+      ],
+      startPairing: vi.fn(),
+      resetStatus: vi.fn(),
+      requestPairing: vi.fn(),
+      status: 'PAIRED',
+      subjectIndex: null,
+      sessionId: null,
+    });
+  });
+
+  it('실험 시작 더블클릭 시 startDualByGroup은 1회만 호출됨', async () => {
+    const measurementApi = await import('@/07-shared/api/signal');
+    const startDualByGroupMock = vi.mocked(
+      measurementApi.default.startDualByGroup
+    );
+    // 시작 호출을 pending 상태로 유지함 — resolve되면 finally가 가드 ref를 해제하므로
+    // 가드 작동 검증을 위해 미해결 Promise 반환함
+    startDualByGroupMock.mockImplementation(
+      () => new Promise(() => {}) as never
+    );
+
+    const user = userEvent.setup();
+    renderLabPage();
+
+    const settingsBtn = screen
+      .getAllByRole('button')
+      .find((b) => b.querySelector('svg.lucide-settings'));
+    if (settingsBtn) await user.click(settingsBtn);
+    const dual2pcBtn = await screen.findByText(/DUAL 2PC 모드/i);
+    await user.click(dual2pcBtn);
+
+    const startBtn = screen.getByRole('button', { name: /실험 시작/ });
+    await user.click(startBtn);
+    await user.click(startBtn);
+
+    expect(startDualByGroupMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/03-pages/lab/lab/lab-page.tsx
+++ b/src/03-pages/lab/lab/lab-page.tsx
@@ -607,9 +607,11 @@ const LabPage = () => {
           <SignalComparisonWidget
             subject1Metrics={subject1Signal.currentMetrics}
             subject2Metrics={
-              currentConfig.targetCount > 1
-                ? subject2Signal.currentMetrics
-                : null
+              mode === 'DUAL_2PC'
+                ? subject1Signal.currentMetrics2
+                : currentConfig.targetCount > 1
+                  ? subject2Signal.currentMetrics
+                  : null
             }
           />
         </section>

--- a/src/03-pages/lab/lab/lab-page.tsx
+++ b/src/03-pages/lab/lab/lab-page.tsx
@@ -5,12 +5,16 @@ import React, {
   useSyncExternalStore,
   useCallback,
   useEffect,
+  useRef,
 } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useSignal } from '@/05-features/signals';
 import { QRGenerator, usePairing } from '@/05-features/sessions';
-import { OperatorInviteQr } from '@/05-features/sessions/ui/operator-invite-qr.component';
 import { useDualSession } from '@/05-features/sessions/model/use-dual-session';
+import {
+  createOperatorInviteToken,
+  joinAsOperator,
+} from '@/07-shared/api/session';
 import { postDualTrigger } from '@/07-shared/api/dual-trigger';
 import measurementApi from '@/07-shared/api/signal';
 import { DualSessionBanner } from '@/04-widgets/dual-session-banner';
@@ -35,7 +39,6 @@ import {
   Square,
   X,
   CheckCircle2,
-  QrCode,
 } from 'lucide-react';
 
 const emptySubscribe = () => () => {};
@@ -73,7 +76,6 @@ const LabPage = () => {
   );
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   // DUAL_2PC 초대 QR 표시 여부 상태 정의함
-  const [isDual2pcQrVisible, setIsDual2pcQrVisible] = useState(false);
 
   // URL query param에서 groupId 파싱 (operator-join 합류 후 리다이렉트 처리)
   const urlGroupId = searchParams?.get('groupId') ?? null;
@@ -117,8 +119,9 @@ const LabPage = () => {
     resetStatus,
   } = usePairing(currentConfig.targetCount, mode);
 
-  // groupId: URL 파라미터 우선, 없으면 페어링에서 가져옴
-  const groupId = urlGroupId ?? pairingGroupId;
+  // groupId: 로컬 신규 페어링 우선, 없으면(순수 합류 PC) URL 파라미터 사용 (F2).
+  // stale URL ?groupId= 가 새 페어링을 덮어쓰는 그룹ID 표류를 차단함.
+  const groupId = pairingGroupId ?? urlGroupId;
 
   // DUAL_2PC 세션 상태 머신 훅 구독함 (Phase 16 FE-4)
   const {
@@ -172,6 +175,9 @@ const LabPage = () => {
   });
   const subject2Signal = useSignal(sessions[1]?.id ?? null);
 
+  // DUAL_2PC 측정 시작 in-flight 가드 — 더블클릭 중복 start 차단함 (F3)
+  const startPendingRef = useRef(false);
+
   /**
    * 모든 활성화된 피실험자의 데이터 측정 시작 수행함
    * DUAL_2PC: groupId 기반 일괄 시작 API 호출함
@@ -180,9 +186,21 @@ const LabPage = () => {
   const handleStartExperiment = useCallback(() => {
     if (mode === 'DUAL_2PC') {
       if (!groupId) return;
-      measurementApi.startDualByGroup(groupId).catch((err: unknown) => {
-        console.error('DUAL_2PC 측정 시작 실패함:', err);
-      });
+      // 중복 클릭 가드 — 진행 중 재클릭은 무시함 (F3). 중복 start는 BE에서
+      // 이미 MEASURING 전이 가드로 400 반환 → dev 오버레이 유발하므로 사전 차단함.
+      if (startPendingRef.current) return;
+      startPendingRef.current = true;
+      // FE 소켓 룸 합류 + aligned_pair 리스너 등록함 (차트 수신 위해 필수)
+      subject1Signal.joinDualRoom();
+      measurementApi
+        .startDualByGroup(groupId)
+        .catch((err: unknown) => {
+          // 이미 MEASURING(중복) 등 비치명 실패 — console.warn으로 dev 오버레이 회피함
+          console.warn('DUAL_2PC 측정 시작 호출 결과:', err);
+        })
+        .finally(() => {
+          startPendingRef.current = false;
+        });
       return;
     }
     subject1Signal.startMeasurement();
@@ -239,8 +257,9 @@ const LabPage = () => {
       setMode(newMode);
       resetStatus();
       setIsQRVisible(false);
-      setIsDual2pcQrVisible(false);
       setIsSettingsOpen(false);
+      setSelfJoinError(null);
+      setSelfJoinPending(false);
     },
     [resetStatus]
   );
@@ -255,6 +274,34 @@ const LabPage = () => {
     // subject2는 BE가 groupId로 일괄 처리하므로 소켓 정리만 수행함
     if (currentConfig.targetCount > 1) {
       void subject2Signal.stopMeasurement();
+    }
+  };
+
+  // operator 자가 합류 상태 정의함 (단일 PC 데모 — invite+join 원클릭)
+  const [selfJoinPending, setSelfJoinPending] = useState(false);
+  const [selfJoinError, setSelfJoinError] = useState<string | null>(null);
+
+  /**
+   * operator가 이 PC에서 직접 그룹에 합류함 — invite-operator 토큰 발급 후
+   * join-as-operator를 한 번에 호출함 (2번째 탭/QR 없이). 단일 PC 강제 페어링
+   * 데모 동선 단축 + operatorJoined 충족으로 자동 트리거 발동시킴.
+   */
+  const handleOperatorSelfJoin = async () => {
+    if (!groupId) return;
+    setSelfJoinPending(true);
+    setSelfJoinError(null);
+    try {
+      const { token } = await createOperatorInviteToken(groupId);
+      await joinAsOperator(token);
+      // operatorJoined=true → 자동 트리거 → use-dual-session 폴링이 partnerConnected 전이
+    } catch (err) {
+      // 실제 오류를 삼키지 않고 콘솔 기록 + BE 메시지 우선 노출함 (진단 가능성 확보)
+      console.error('[handleOperatorSelfJoin]', err);
+      const beMsg = (err as { response?: { data?: { message?: string } } })
+        ?.response?.data?.message;
+      setSelfJoinError(beMsg ?? 'operator 합류 실패 — 다시 시도 필요함.');
+    } finally {
+      setSelfJoinPending(false);
     }
   };
 
@@ -342,46 +389,44 @@ const LabPage = () => {
         );
       }
 
-      // 페어링 완료 후 파트너 PC 초대 QR 버튼 표시함 (showFallback 포함)
-      // showFallback=true → QR 버튼 + 수동 재연결 버튼 병렬 노출함
-      if (showFallback) {
-        return (
-          <div className="flex flex-col gap-3 items-center">
-            <button
-              onClick={() => setIsDual2pcQrVisible((prev) => !prev)}
-              className="group relative inline-flex items-center cursor-pointer gap-2 px-6 py-3 bg-violet-600 hover:bg-violet-500 text-white rounded-2xl font-bold transition-all duration-300 hover:scale-105 shadow-lg shadow-violet-500/20"
-            >
-              {isDual2pcQrVisible ? <X size={20} /> : <QrCode size={20} />}
-              <span>{isDual2pcQrVisible ? '닫기' : '파트너 PC 초대 QR'}</span>
-            </button>
-            <button
-              onClick={() => void handleManualTrigger()}
-              disabled={manualTriggerPending || !!registryStatus?.ready}
-              className={`text-sm ${
-                manualTriggerError ? 'text-rose-500' : 'text-amber-500'
-              } underline disabled:opacity-50`}
-            >
-              {manualTriggerPending
-                ? '연결 시도 중...'
-                : '엔진 연결이 지연됩니다. 다시 연결 시도'}
-            </button>
-            {manualTriggerError ? (
-              <p className="text-xs text-rose-500 max-w-md">
-                {manualTriggerError}
-              </p>
-            ) : null}
-          </div>
-        );
-      }
-
+      // 페어링 완료 후 operator 합류(이 PC 원클릭) 1차 + 파트너 PC 초대 QR(2-PC) 보조 표시함
       return (
-        <button
-          onClick={() => setIsDual2pcQrVisible((prev) => !prev)}
-          className="group relative inline-flex items-center cursor-pointer gap-2 px-6 py-3 bg-violet-600 hover:bg-violet-500 text-white rounded-2xl font-bold transition-all duration-300 hover:scale-105 shadow-lg shadow-violet-500/20"
-        >
-          {isDual2pcQrVisible ? <X size={20} /> : <QrCode size={20} />}
-          <span>{isDual2pcQrVisible ? '닫기' : '파트너 PC 초대 QR'}</span>
-        </button>
+        <div className="flex flex-col gap-3 items-center">
+          <button
+            data-testid="operator-self-join"
+            onClick={() => void handleOperatorSelfJoin()}
+            disabled={selfJoinPending}
+            className="group relative inline-flex items-center cursor-pointer gap-2 px-8 py-3 bg-emerald-600 hover:bg-emerald-500 text-white rounded-2xl font-black transition-all duration-300 hover:scale-105 shadow-lg shadow-emerald-500/20 disabled:opacity-50"
+          >
+            <CheckCircle2 size={20} />
+            <span>
+              {selfJoinPending ? '합류 중...' : 'operator 합류 (이 PC)'}
+            </span>
+          </button>
+          {selfJoinError ? (
+            <p className="text-xs text-rose-500 max-w-md">{selfJoinError}</p>
+          ) : null}
+          {showFallback ? (
+            <>
+              <button
+                onClick={() => void handleManualTrigger()}
+                disabled={manualTriggerPending || !!registryStatus?.ready}
+                className={`text-sm ${
+                  manualTriggerError ? 'text-rose-500' : 'text-amber-500'
+                } underline disabled:opacity-50`}
+              >
+                {manualTriggerPending
+                  ? '연결 시도 중...'
+                  : '엔진 연결이 지연됩니다. 다시 연결 시도'}
+              </button>
+              {manualTriggerError ? (
+                <p className="text-xs text-rose-500 max-w-md">
+                  {manualTriggerError}
+                </p>
+              ) : null}
+            </>
+          ) : null}
+        </div>
       );
     }
 
@@ -530,47 +575,6 @@ const LabPage = () => {
             </div>
           </div>
         </header>
-
-        {/* DUAL_2PC 파트너 PC 초대 QR 표시 (PLAN L175-180) */}
-        {mode === 'DUAL_2PC' && isDual2pcQrVisible && groupId ? (
-          <section className="animate-in fade-in zoom-in duration-500">
-            <div
-              className={`p-8 rounded-[2.5rem] border backdrop-blur-sm flex flex-col items-center gap-6 ${
-                isDark
-                  ? 'bg-violet-500/5 border-violet-500/20'
-                  : 'bg-white/80 border-violet-100 shadow-sm'
-              }`}
-            >
-              <p
-                className={`text-xs font-bold uppercase tracking-widest ${isDark ? 'text-violet-400' : 'text-violet-600'}`}
-              >
-                DUAL 2PC · 파트너 PC 초대
-              </p>
-              <OperatorInviteQr
-                groupId={groupId}
-                isDark={isDark}
-                onClose={() => setIsDual2pcQrVisible(false)}
-              />
-            </div>
-          </section>
-        ) : null}
-
-        {/* DUAL_2PC groupId 없을 때 안내 메시지 */}
-        {mode === 'DUAL_2PC' && isDual2pcQrVisible && !groupId ? (
-          <section className="animate-in fade-in zoom-in duration-500">
-            <div
-              className={`p-8 rounded-[2.5rem] border text-center ${
-                isDark
-                  ? 'bg-white/[0.02] border-white/5 text-slate-400'
-                  : 'bg-white border-slate-200 text-slate-600'
-              }`}
-            >
-              <p className="text-sm font-bold">
-                먼저 Subject를 페어링하여 groupId를 생성해야 함
-              </p>
-            </div>
-          </section>
-        ) : null}
 
         {/* 기존 페어링 QR — DUAL_2PC 포함 페어링 진행 중 표시함 */}
         {isQRVisible &&

--- a/src/05-features/dev-mode/ui/admin-force-pair-modal.component.tsx
+++ b/src/05-features/dev-mode/ui/admin-force-pair-modal.component.tsx
@@ -83,22 +83,25 @@ const AdminForcePairModal: React.FC<AdminForcePairModalProps> = ({
         return;
       }
       const status = axiosError.response?.status;
+      // BE AppError 메시지를 우선 표시함 — 400을 무조건 '이메일 형식'으로 오매핑하지 않음
+      // (예: 이미 PAIRED된 세션 재페어링 시 '현재 세션 상태(PAIRED)에서는...' 그대로 노출)
+      const beMessage = axiosError.response?.data?.message;
       switch (status) {
         case 401:
-          setError('재로그인 후 다시 시도 필요함.');
+          setError(beMessage ?? '재로그인 후 다시 시도 필요함.');
           break;
         case 403:
-          setError('관리자 권한이 필요함.');
+          setError(beMessage ?? '관리자 권한이 필요함.');
           break;
         case 404:
-          setError('대상 사용자 또는 토큰 불일치 발생함.');
+          setError(beMessage ?? '대상 사용자 또는 토큰 불일치 발생함.');
           break;
         case 400:
-          setError('이메일 형식 확인 필요함.');
+          setError(beMessage ?? '이메일 형식 확인 필요함.');
           break;
         default:
           // network down (response=undefined) + 5xx 모두 default 분기 처리함
-          setError('요청 처리 실패함. 다시 시도 필요함.');
+          setError(beMessage ?? '요청 처리 실패함. 다시 시도 필요함.');
       }
     } finally {
       // abort 후 stale finally가 새 state 덮어쓰지 않도록 가드 처리함

--- a/src/05-features/signals/model/use-signal.test.ts
+++ b/src/05-features/signals/model/use-signal.test.ts
@@ -270,6 +270,48 @@ describe('useSignal DUAL_2PC — join-room emit + stimulus 테스트 수행함',
     expect(result.current.currentMetrics?.stress).toBe(subject1Wave.delta);
   });
 
+  it('aligned_pair subject_1:null + subject_2 수신 시 currentMetrics2만 업데이트됨 (단일 헤드셋)', async () => {
+    const { result } = renderHook(() =>
+      useSignal('session-abc', {
+        experimentMode: 'DUAL_2PC',
+        groupId: 'group-xyz',
+        setDualSessionState: mockSetDualSessionState,
+      })
+    );
+
+    await act(async () => {
+      await result.current.startMeasurement();
+    });
+
+    const alignedPairHandler = getSocketHandler('aligned_pair');
+    expect(alignedPairHandler).not.toBeNull();
+
+    const subject2Wave = {
+      delta: 0.6,
+      theta: 0.7,
+      alpha: 0.8,
+      beta: 0.9,
+      gamma: 1.0,
+    };
+
+    act(() => {
+      // 노트북 B(subject 2)만 측정 — subject_1 없음
+      alignedPairHandler!({
+        groupId: 'group-xyz',
+        timestamp_ms: Date.now(),
+        subject_1: null,
+        subject_2: subject2Wave,
+      });
+    });
+
+    // subject_1 없음 → currentMetrics는 null 유지, subject_2 → currentMetrics2 업데이트됨
+    expect(result.current.currentMetrics).toBeNull();
+    expect(result.current.currentMetrics2).not.toBeNull();
+    expect(result.current.currentMetrics2?.focus).toBe(subject2Wave.beta);
+    expect(result.current.currentMetrics2?.excitement).toBe(subject2Wave.gamma);
+    expect(result.current.currentMetrics2?.stress).toBe(subject2Wave.delta);
+  });
+
   it('aligned_pair 수신 시 다른 groupId이면 currentMetrics 미업데이트 처리됨', async () => {
     const { result } = renderHook(() =>
       useSignal('session-abc', {

--- a/src/05-features/signals/model/use-signal.test.ts
+++ b/src/05-features/signals/model/use-signal.test.ts
@@ -312,6 +312,40 @@ describe('useSignal DUAL_2PC — join-room emit + stimulus 테스트 수행함',
     expect(result.current.currentMetrics2?.stress).toBe(subject2Wave.delta);
   });
 
+  it('aligned_pair subject_2에 비유한 값(NaN) 포함 시 currentMetrics2 미갱신 처리됨 (차트 깨짐 방지)', async () => {
+    const { result } = renderHook(() =>
+      useSignal('session-abc', {
+        experimentMode: 'DUAL_2PC',
+        groupId: 'group-xyz',
+        setDualSessionState: mockSetDualSessionState,
+      })
+    );
+
+    await act(async () => {
+      await result.current.startMeasurement();
+    });
+
+    const alignedPairHandler = getSocketHandler('aligned_pair');
+
+    act(() => {
+      alignedPairHandler!({
+        groupId: 'group-xyz',
+        timestamp_ms: Date.now(),
+        subject_1: null,
+        subject_2: {
+          delta: NaN,
+          theta: 0.7,
+          alpha: 0.8,
+          beta: 0.9,
+          gamma: 1.0,
+        },
+      });
+    });
+
+    // NaN 한 번이라도 들어오면 currentMetrics2는 null 유지 (차트로 전파 차단)
+    expect(result.current.currentMetrics2).toBeNull();
+  });
+
   it('aligned_pair 수신 시 다른 groupId이면 currentMetrics 미업데이트 처리됨', async () => {
     const { result } = renderHook(() =>
       useSignal('session-abc', {

--- a/src/05-features/signals/model/use-signal.ts
+++ b/src/05-features/signals/model/use-signal.ts
@@ -91,6 +91,34 @@ interface UseSignalOptions {
 }
 
 /**
+ * WavePower를 EmotivMetrics로 변환함 (간이 변환). 비유한(NaN/Infinity) 값이
+ * 하나라도 있으면 null 반환해 차트 깨짐을 방지함 — eeg-live 경로 finite 검증과 정합.
+ * subject_1/subject_2 동일 적용 (CodeRabbit #60).
+ *
+ * @param wave - 5대역 파워 값
+ * @returns EmotivMetrics 또는 비유한 값 포함 시 null
+ */
+const wavePowerToEmotivMetrics = (wave: WavePower): EmotivMetrics | null => {
+  if (
+    !Number.isFinite(wave.delta) ||
+    !Number.isFinite(wave.theta) ||
+    !Number.isFinite(wave.alpha) ||
+    !Number.isFinite(wave.beta) ||
+    !Number.isFinite(wave.gamma)
+  ) {
+    return null;
+  }
+  return {
+    focus: wave.beta,
+    engagement: wave.alpha,
+    interest: wave.theta,
+    excitement: wave.gamma,
+    stress: wave.delta,
+    relaxation: wave.alpha,
+  };
+};
+
+/**
  * [Feature] sessionId 기반 실시간 EEG 측정 제어 훅 정의함
  * HTTP POST 1회로 측정 트리거 후 Socket.io eeg-live 이벤트로 데이터 수신함
  *
@@ -241,33 +269,21 @@ const useSignal = (sessionId: string | null, options?: UseSignalOptions) => {
         subject_2,
       }: AlignedPairPayload) => {
         if (incomingGid !== gid) return; // 다른 그룹 이벤트 무시함
-        // subject_1 데이터 기준으로 currentMetrics 업데이트 (EEG 시각화용)
-        // WavePower → EmotivMetrics 매핑 (알파/베타 기반 간이 변환)
+        // subject_1 데이터 기준으로 currentMetrics 업데이트함 (finite 검증, CodeRabbit #60)
         if (subject_1) {
-          const metrics: EmotivMetrics = {
-            focus: subject_1.beta,
-            engagement: subject_1.alpha,
-            interest: subject_1.theta,
-            excitement: subject_1.gamma,
-            stress: subject_1.delta,
-            relaxation: subject_1.alpha,
-          };
-          setCurrentMetrics(metrics);
-          setLastReceivedTime(new Date().toLocaleTimeString());
+          const metrics = wavePowerToEmotivMetrics(subject_1);
+          if (metrics) {
+            setCurrentMetrics(metrics);
+            setLastReceivedTime(new Date().toLocaleTimeString());
+          }
         }
-        // subject_2(노트북 B) 데이터 → currentMetrics2 변환함 (단일 헤드셋 지원)
-        // subject_1 매핑과 동일 (간이 변환). ponytail: 6줄 인라인 미러, 헬퍼 불필요.
+        // subject_2(노트북 B) 데이터 → currentMetrics2 업데이트함 (단일 헤드셋 지원)
         if (subject_2) {
-          const metrics2: EmotivMetrics = {
-            focus: subject_2.beta,
-            engagement: subject_2.alpha,
-            interest: subject_2.theta,
-            excitement: subject_2.gamma,
-            stress: subject_2.delta,
-            relaxation: subject_2.alpha,
-          };
-          setCurrentMetrics2(metrics2);
-          setLastReceivedTime(new Date().toLocaleTimeString());
+          const metrics2 = wavePowerToEmotivMetrics(subject_2);
+          if (metrics2) {
+            setCurrentMetrics2(metrics2);
+            setLastReceivedTime(new Date().toLocaleTimeString());
+          }
         }
       };
 

--- a/src/05-features/signals/model/use-signal.ts
+++ b/src/05-features/signals/model/use-signal.ts
@@ -106,6 +106,10 @@ const useSignal = (sessionId: string | null, options?: UseSignalOptions) => {
   const [currentMetrics, setCurrentMetrics] = useState<EmotivMetrics | null>(
     null
   );
+  // 단일 헤드셋 지원 — subject 2(노트북 B) 메트릭 상태 정의함
+  const [currentMetrics2, setCurrentMetrics2] = useState<EmotivMetrics | null>(
+    null
+  );
   const [lastReceivedTime, setLastReceivedTime] = useState<string | null>(null);
   // 측정 경과 시간(초) 상태 정의함
   const [elapsedSeconds, setElapsedSeconds] = useState(0);
@@ -251,9 +255,19 @@ const useSignal = (sessionId: string | null, options?: UseSignalOptions) => {
           setCurrentMetrics(metrics);
           setLastReceivedTime(new Date().toLocaleTimeString());
         }
-        // subject_2 수신 확인 로그 (향후 두 subject 동시 차트 지원 시 확장)
+        // subject_2(노트북 B) 데이터 → currentMetrics2 변환함 (단일 헤드셋 지원)
+        // subject_1 매핑과 동일 (간이 변환). ponytail: 6줄 인라인 미러, 헬퍼 불필요.
         if (subject_2) {
-          console.info('aligned_pair subject_2 수신 완료함');
+          const metrics2: EmotivMetrics = {
+            focus: subject_2.beta,
+            engagement: subject_2.alpha,
+            interest: subject_2.theta,
+            excitement: subject_2.gamma,
+            stress: subject_2.delta,
+            relaxation: subject_2.alpha,
+          };
+          setCurrentMetrics2(metrics2);
+          setLastReceivedTime(new Date().toLocaleTimeString());
         }
       };
 
@@ -470,6 +484,7 @@ const useSignal = (sessionId: string | null, options?: UseSignalOptions) => {
   return {
     isMeasuring,
     currentMetrics,
+    currentMetrics2,
     lastReceivedTime,
     elapsedSeconds,
     roomJoined,

--- a/src/05-features/signals/model/use-signal.ts
+++ b/src/05-features/signals/model/use-signal.ts
@@ -325,6 +325,41 @@ const useSignal = (sessionId: string | null, options?: UseSignalOptions) => {
   }, []);
 
   /**
+   * DUAL_2PC 소켓 룸 합류 + 리스너 등록만 수행함 (HTTP spawn 없음).
+   * 측정은 그룹 단위 startDualByGroup으로 트리거되고, FE는 이 메서드로 룸에 합류해
+   * aligned_pair를 수신함 — handleStartExperiment(DUAL_2PC)에서 호출.
+   */
+  const joinDualRoom = useCallback(() => {
+    if (!isDual2pc || !groupId) return;
+    setDualSessionState?.('joining');
+    setIsMeasuring(true);
+
+    const socket = getSocket(config.api.socketUrl ?? config.api.baseUrl);
+    emitJoinRoom(groupId);
+    registerDualListeners(groupId);
+
+    const completeHandler = (
+      payload: MeasurementCompletePayload & { groupId?: string }
+    ) => {
+      if ((payload.groupId ?? null) !== groupId) return; // 다른 그룹 무시함
+      setIsMeasuring(false);
+      setDualSessionState?.('completed');
+      if (timerRef.current) {
+        clearInterval(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+    completeHandlerRef.current = completeHandler;
+    socket.on('measurement-complete', completeHandler);
+  }, [
+    isDual2pc,
+    groupId,
+    setDualSessionState,
+    emitJoinRoom,
+    registerDualListeners,
+  ]);
+
+  /**
    * 측정 시작 처리함
    *
    * DUAL_2PC: 202 Accepted 수신 → setIsMeasuring(true) 즉시 금지 (v3 N-5)
@@ -505,6 +540,7 @@ const useSignal = (sessionId: string | null, options?: UseSignalOptions) => {
     elapsedSeconds,
     roomJoined,
     startMeasurement,
+    joinDualRoom,
     stopMeasurement,
   };
 };

--- a/src/07-shared/api/session.test.ts
+++ b/src/07-shared/api/session.test.ts
@@ -152,8 +152,12 @@ describe('createOperatorInviteToken — operator-invite API 클라이언트 테�
 
   it('성공 시 POST /sessions/:groupId/invite-operator 호출 처리함', async () => {
     const expiresAt = Date.now() + 300_000;
+    // BE 응답 envelope { status, data } — 구현이 response.data.data 언래핑함
     mockPost.mockResolvedValue({
-      data: { token: 'jwt-invite-token', expiresAt },
+      data: {
+        status: 'success',
+        data: { token: 'jwt-invite-token', expiresAt },
+      },
     });
 
     const result = await createOperatorInviteToken('group-abc');
@@ -192,8 +196,12 @@ describe('joinAsOperator — join-as-operator API 클라이언트 테스트 수�
   });
 
   it('성공 시 POST /sessions/join-as-operator 호출 처리함', async () => {
+    // BE 응답 envelope { status, data } — 구현이 response.data.data 언래핑함
     mockPost.mockResolvedValue({
-      data: { groupId: 'group-xyz', experimentMode: 'DUAL_2PC' },
+      data: {
+        status: 'success',
+        data: { groupId: 'group-xyz', experimentMode: 'DUAL_2PC' },
+      },
     });
 
     const result = await joinAsOperator('valid-jwt-token');

--- a/src/07-shared/api/session.ts
+++ b/src/07-shared/api/session.ts
@@ -96,11 +96,13 @@ export default sessionApi;
 export async function createOperatorInviteToken(
   groupId: string
 ): Promise<{ token: string; expiresAt: number }> {
-  // POST /api/sessions/:groupId/invite-operator (authenticate 미들웨어 적용)
-  const response = await api.post<{ token: string; expiresAt: number }>(
-    `/sessions/${groupId}/invite-operator`
-  );
-  return response.data;
+  // POST /api/sessions/:groupId/invite-operator — 응답 envelope { status, data } 언래핑함
+  // (BE controller가 res.json({ status, data: { token, expiresAt } }) 반환 — data.data가 실제 페이로드)
+  const response = await api.post<{
+    status: string;
+    data: { token: string; expiresAt: number };
+  }>(`/sessions/${groupId}/invite-operator`);
+  return response.data.data;
 }
 
 /**
@@ -113,10 +115,10 @@ export async function createOperatorInviteToken(
 export async function joinAsOperator(
   token: string
 ): Promise<{ groupId: string; experimentMode: 'DUAL_2PC' }> {
-  // POST /api/sessions/join-as-operator (authenticate 미적용 — JWT body 검증만)
+  // POST /api/sessions/join-as-operator — 응답 envelope { status, data } 언래핑함
   const response = await api.post<{
-    groupId: string;
-    experimentMode: 'DUAL_2PC';
+    status: string;
+    data: { groupId: string; experimentMode: 'DUAL_2PC' };
   }>('/sessions/join-as-operator', { token });
-  return response.data;
+  return response.data.data;
 }


### PR DESCRIPTION
## 배경
DUAL_2PC 모드에서 aligned_pair 핸들러는 subject_1만 차트 메트릭으로 변환하고 subject_2는 로그만 찍어 버렸다("향후 확장" 주석). 그래서 헤드셋이 1대(노트북 B=subject 2)뿐이면 operator 화면에 신호가 뜨지 않았다.

## 변경
- `use-signal.ts`: `currentMetrics2` 상태 추가, aligned_pair의 subject_2를 EmotivMetrics로 변환(subject_1 매핑 인라인 미러)해 노출. 기존 subject_1 경로 불변.
- `lab-page.tsx`: DUAL_2PC 모드면 subject2Metrics를 `subject1Signal.currentMetrics2`로 연결. non-DUAL_2PC 경로 보존.

## 테스트
- 신규: subject_1:null + subject_2 수신 시 currentMetrics2만 갱신, currentMetrics는 null 유지
- 회귀 유지: subject_1 매핑, 다른 groupId 무시, 리스너 등록
- FE verify 통과: typecheck/lint/test/build OK

## 비고
BE 단독 emit은 mind-signal-backend PR #68과 짝.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 듀얼 2PC에서 두 번째 측정값을 별도로 제공해 두 신호를 더 명확히 확인할 수 있도록 개선했습니다.
  * 페어링 완료 후 “파트너 PC 초대 QR” 대신 “이 PC로 operator 합류” 원클릭 버튼을 추가했습니다.
* **버그 수정**
  * “실험 시작” 버튼 더블클릭/중복 실행을 방지했습니다.
  * 비정상 수치(NaN/Infinity) 수신 시 두 번째 측정값 갱신을 차단해 차트 오류를 예방합니다.
* **테스트**
  * 듀얼 수신/비정상 값, 중복 실행 방지, URL 그룹 조건, self-join UI를 검증하는 케이스를 추가·보완했습니다.
* **문서/안내**
  * 관리자 모달에서 서버 에러 메시지를 우선 표시하도록 조정했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->