### PR TITLE
fix(lab): CodeRabbit 지적 반영 — 측정 시작 에러 처리 + self-join 테스트

### DIFF
--- a/src/03-pages/lab/lab/lab-page.test.tsx
+++ b/src/03-pages/lab/lab/lab-page.test.tsx
@@ -93,6 +93,15 @@ vi.mock('@/07-shared/api/auth', () => ({
   },
 }));
 
+/**
+ * operator self-join API mock — handleOperatorSelfJoin 클릭 경로 테스트용 (CodeRabbit #60)
+ */
+vi.mock('@/07-shared/api/session', () => ({
+  default: {},
+  createOperatorInviteToken: vi.fn(),
+  joinAsOperator: vi.fn(),
+}));
+
 import { useDualSession } from '@/05-features/sessions/model/use-dual-session';
 import { usePairing } from '@/05-features/sessions';
 import LabPage from './lab-page';
@@ -796,5 +805,158 @@ describe('LabPage F3 — 실험 시작 중복 클릭 가드', () => {
     await user.click(startBtn);
 
     expect(startDualByGroupMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+/**
+ * CodeRabbit #60 — 측정 시작 실패를 전부 비치명으로 삼키지 않음
+ * 400(중복/MEASURING)만 무시하고 401/500/네트워크는 visible error로 노출함.
+ */
+describe('LabPage CR — 측정 시작 실패 visible error', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(window, 'innerWidth', {
+      writable: true,
+      configurable: true,
+      value: 1280,
+    });
+    mockSearchParamsGet.mockReturnValue(null);
+    (useDualSession as ReturnType<typeof vi.fn>).mockReturnValue({
+      state: 'ready',
+      partnerConnected: true,
+      registryStatus: null,
+      showFallback: false,
+      setDualSessionState: vi.fn(),
+    });
+    (usePairing as ReturnType<typeof vi.fn>).mockReturnValue({
+      groupId: 'group-err',
+      pairingCode: null,
+      timeLeft: 300,
+      pairedSubjects: [1, 2],
+      isAllPaired: true,
+      sessions: [
+        { id: 's1', subjectIndex: 1 },
+        { id: 's2', subjectIndex: 2 },
+      ],
+      startPairing: vi.fn(),
+      resetStatus: vi.fn(),
+      requestPairing: vi.fn(),
+      status: 'PAIRED',
+      subjectIndex: null,
+      sessionId: null,
+    });
+  });
+
+  const openDual2pcAndStart = async () => {
+    const user = userEvent.setup();
+    renderLabPage();
+    const settingsBtn = screen
+      .getAllByRole('button')
+      .find((b) => b.querySelector('svg.lucide-settings'));
+    if (settingsBtn) await user.click(settingsBtn);
+    await user.click(await screen.findByText(/DUAL 2PC 모드/i));
+    await user.click(screen.getByRole('button', { name: /실험 시작/ }));
+  };
+
+  it('startDualByGroup 500 실패 시 visible error 표시함', async () => {
+    const measurementApi = await import('@/07-shared/api/signal');
+    vi.mocked(measurementApi.default.startDualByGroup).mockRejectedValue({
+      response: { status: 500 },
+    });
+
+    await openDual2pcAndStart();
+
+    expect(await screen.findByText(/측정 시작 실패/)).toBeInTheDocument();
+  });
+
+  it('startDualByGroup 400(중복) 실패는 error 안 띄움', async () => {
+    const measurementApi = await import('@/07-shared/api/signal');
+    vi.mocked(measurementApi.default.startDualByGroup).mockRejectedValue({
+      response: { status: 400 },
+    });
+
+    await openDual2pcAndStart();
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(screen.queryByText(/측정 시작 실패/)).not.toBeInTheDocument();
+  });
+});
+
+/**
+ * CodeRabbit #60 — operator self-join 클릭 동작 커버리지
+ * 버튼 표시뿐 아니라 클릭 후 pending(합류 중...) + BE 오류 메시지 노출을 검증함.
+ */
+describe('LabPage CR — operator self-join 클릭 경로', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(window, 'innerWidth', {
+      writable: true,
+      configurable: true,
+      value: 1280,
+    });
+    mockSearchParamsGet.mockReturnValue(null);
+    // 페어링 완료 + partnerConnected=false → operator 합류(이 PC) 버튼 노출
+    (useDualSession as ReturnType<typeof vi.fn>).mockReturnValue({
+      state: 'waiting',
+      partnerConnected: false,
+      registryStatus: null,
+      showFallback: false,
+      setDualSessionState: vi.fn(),
+    });
+    (usePairing as ReturnType<typeof vi.fn>).mockReturnValue({
+      groupId: 'group-selfjoin',
+      pairingCode: null,
+      timeLeft: 300,
+      pairedSubjects: [1, 2],
+      isAllPaired: true,
+      sessions: [
+        { id: 's1', subjectIndex: 1 },
+        { id: 's2', subjectIndex: 2 },
+      ],
+      startPairing: vi.fn(),
+      resetStatus: vi.fn(),
+      requestPairing: vi.fn(),
+      status: 'PAIRED',
+      subjectIndex: null,
+      sessionId: null,
+    });
+  });
+
+  const openDual2pcAndClickJoin = async () => {
+    const user = userEvent.setup();
+    renderLabPage();
+    const settingsBtn = screen
+      .getAllByRole('button')
+      .find((b) => b.querySelector('svg.lucide-settings'));
+    if (settingsBtn) await user.click(settingsBtn);
+    await user.click(await screen.findByText(/DUAL 2PC 모드/i));
+    await user.click(screen.getByTestId('operator-self-join'));
+  };
+
+  it('합류 클릭 시 합류 중... pending 표시함', async () => {
+    const sessionMod = await import('@/07-shared/api/session');
+    // invite 토큰 발급이 진행 중인 동안 pending 상태 유지
+    vi.mocked(sessionMod.createOperatorInviteToken).mockReturnValue(
+      new Promise(() => {}) as never
+    );
+
+    await openDual2pcAndClickJoin();
+
+    expect(await screen.findByText(/합류 중/)).toBeInTheDocument();
+  });
+
+  it('합류 실패 시 BE 오류 메시지 노출함', async () => {
+    const sessionMod = await import('@/07-shared/api/session');
+    vi.mocked(sessionMod.createOperatorInviteToken).mockResolvedValue({
+      token: 'tok',
+      expiresAt: 9999999999999,
+    });
+    vi.mocked(sessionMod.joinAsOperator).mockRejectedValue({
+      response: { data: { message: 'operator 합류 거부됨' } },
+    });
+
+    await openDual2pcAndClickJoin();
+
+    expect(await screen.findByText(/operator 합류 거부됨/)).toBeInTheDocument();
   });
 });

--- a/src/03-pages/lab/lab/lab-page.test.tsx
+++ b/src/03-pages/lab/lab/lab-page.test.tsx
@@ -869,16 +869,33 @@ describe('LabPage CR — 측정 시작 실패 visible error', () => {
     expect(await screen.findByText(/측정 시작 실패/)).toBeInTheDocument();
   });
 
-  it('startDualByGroup 400(중복) 실패는 error 안 띄움', async () => {
+  it('startDualByGroup 400(이미 MEASURING 기대 메시지)는 error 안 띄움', async () => {
     const measurementApi = await import('@/07-shared/api/signal');
     vi.mocked(measurementApi.default.startDualByGroup).mockRejectedValue({
-      response: { status: 400 },
+      response: {
+        status: 400,
+        data: {
+          message:
+            '그룹 내 전이 불가 세션이 존재하여 측정을 시작할 수 없습니다.',
+        },
+      },
     });
 
     await openDual2pcAndStart();
     await new Promise((r) => setTimeout(r, 50));
 
     expect(screen.queryByText(/측정 시작 실패/)).not.toBeInTheDocument();
+  });
+
+  it('startDualByGroup 400(예상 외 메시지)는 visible error 표시함', async () => {
+    const measurementApi = await import('@/07-shared/api/signal');
+    vi.mocked(measurementApi.default.startDualByGroup).mockRejectedValue({
+      response: { status: 400, data: { message: '잘못된 요청입니다.' } },
+    });
+
+    await openDual2pcAndStart();
+
+    expect(await screen.findByText(/잘못된 요청입니다/)).toBeInTheDocument();
   });
 });
 

--- a/src/03-pages/lab/lab/lab-page.tsx
+++ b/src/03-pages/lab/lab/lab-page.tsx
@@ -177,6 +177,8 @@ const LabPage = () => {
 
   // DUAL_2PC 측정 시작 in-flight 가드 — 더블클릭 중복 start 차단함 (F3)
   const startPendingRef = useRef(false);
+  // 측정 시작 실패 메시지 — 401/500/네트워크 등 기대 못 한 오류만 노출함 (CodeRabbit #60)
+  const [startError, setStartError] = useState<string | null>(null);
 
   /**
    * 모든 활성화된 피실험자의 데이터 측정 시작 수행함
@@ -190,13 +192,23 @@ const LabPage = () => {
       // 이미 MEASURING 전이 가드로 400 반환 → dev 오버레이 유발하므로 사전 차단함.
       if (startPendingRef.current) return;
       startPendingRef.current = true;
+      setStartError(null);
       // FE 소켓 룸 합류 + aligned_pair 리스너 등록함 (차트 수신 위해 필수)
       subject1Signal.joinDualRoom();
       measurementApi
         .startDualByGroup(groupId)
         .catch((err: unknown) => {
-          // 이미 MEASURING(중복) 등 비치명 실패 — console.warn으로 dev 오버레이 회피함
-          console.warn('DUAL_2PC 측정 시작 호출 결과:', err);
+          const status = (err as { response?: { status?: number } })?.response
+            ?.status;
+          // 중복 클릭/이미 MEASURING 등 기대 가능한 400만 무시함 (dev 오버레이 회피)
+          if (status === 400) {
+            console.warn('DUAL_2PC 측정 시작 중복 호출 무시:', err);
+            return;
+          }
+          // 401/500/네트워크 등은 버튼 근처 visible error로 노출함 (CodeRabbit #60)
+          const beMsg = (err as { response?: { data?: { message?: string } } })
+            ?.response?.data?.message;
+          setStartError(beMsg ?? '측정 시작 실패 — 다시 시도 필요함.');
         })
         .finally(() => {
           startPendingRef.current = false;
@@ -353,13 +365,18 @@ const LabPage = () => {
 
     if (mode === 'DUAL_2PC' ? partnerConnected : isAllPaired) {
       return (
-        <button
-          onClick={handleStartExperiment}
-          className="group relative inline-flex items-center cursor-pointer gap-2 px-8 py-3 bg-emerald-600 hover:bg-emerald-500 text-white rounded-2xl font-black transition-all duration-300 hover:scale-105 shadow-lg shadow-emerald-500/20"
-        >
-          <Play size={20} fill="currentColor" />
-          <span>실험 시작</span>
-        </button>
+        <div className="flex flex-col gap-3 items-center">
+          <button
+            onClick={handleStartExperiment}
+            className="group relative inline-flex items-center cursor-pointer gap-2 px-8 py-3 bg-emerald-600 hover:bg-emerald-500 text-white rounded-2xl font-black transition-all duration-300 hover:scale-105 shadow-lg shadow-emerald-500/20"
+          >
+            <Play size={20} fill="currentColor" />
+            <span>실험 시작</span>
+          </button>
+          {startError ? (
+            <p className="text-xs text-rose-500 max-w-md">{startError}</p>
+          ) : null}
+        </div>
       );
     }
 

--- a/src/03-pages/lab/lab/lab-page.tsx
+++ b/src/03-pages/lab/lab/lab-page.tsx
@@ -200,14 +200,20 @@ const LabPage = () => {
         .catch((err: unknown) => {
           const status = (err as { response?: { status?: number } })?.response
             ?.status;
-          // 중복 클릭/이미 MEASURING 등 기대 가능한 400만 무시함 (dev 오버레이 회피)
-          if (status === 400) {
-            console.warn('DUAL_2PC 측정 시작 중복 호출 무시:', err);
-            return;
-          }
-          // 401/500/네트워크 등은 버튼 근처 visible error로 노출함 (CodeRabbit #60)
           const beMsg = (err as { response?: { data?: { message?: string } } })
             ?.response?.data?.message;
+          // "지금 시작 불가"인 기대 가능한 400(이미 MEASURING/모드 불일치)만 무시함
+          // (F3 더블클릭 + dev 오버레이 회피). 그 외 400 및 401/500/네트워크는 모두
+          // visible error로 노출함 — 400 전체를 삼키지 않음 (CodeRabbit #61).
+          const isExpectedStartBlock =
+            status === 400 &&
+            !!beMsg &&
+            (beMsg.includes('측정을 시작할 수 없습니다') ||
+              beMsg.includes('DUAL_2PC 모드만'));
+          if (isExpectedStartBlock) {
+            console.warn('DUAL_2PC 측정 시작 차단(기대):', err);
+            return;
+          }
           setStartError(beMsg ?? '측정 시작 실패 — 다시 시도 필요함.');
         })
         .finally(() => {


### PR DESCRIPTION
## CodeRabbit #60 반영
- startDualByGroup 실패를 전부 삼키지 않음: 400(중복/MEASURING)만 무시, 401/500/네트워크는 버튼 근처 visible error로 노출 (Major)
- operator self-join 클릭 경로 테스트 추가 (pending 합류 중... + BE 오류 메시지, Minor)

## 테스트
TDD red→green, 풀 verify GREEN + build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * DUAL_2PC 측정 시작이 실패할 때 화면에 오류 메시지가 표시되도록 개선했습니다.
  * 중복 시작과 같은 예상 가능한 실패는 안내하지 않고, 그 외 오류는 상세 메시지로 보여줍니다.
  * 오퍼레이터 합류 과정에서 진행 중 상태가 유지되고, 합류 실패 시 서버에서 전달한 오류가 화면에 노출됩니다.
* **테스트**
  * 측정 시작 실패 및 오퍼레이터 합류 관련 회귀 시나리오를 추가해 오류 표시 동작을 검증했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->